### PR TITLE
Revert "Bump danielpalme/ReportGenerator-GitHub-Action from 5.2.4 to 5.2.5"

### DIFF
--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Combine Coverage Reports
         if: runner.os == 'Linux'
-        uses: danielpalme/ReportGenerator-GitHub-Action@5.2.5
+        uses: danielpalme/ReportGenerator-GitHub-Action@5.2.4
         with:
           reports: "**/*.cobertura.xml"
           targetdir: "${{ github.workspace }}"


### PR DESCRIPTION
Reverts petabridge/TurboMqtt#33

Pretty sure this broke test output reporting