### PR TITLE
Allow `IMqttClient` to reconnect after failed `ConnectAsync` without having to be recreated

### DIFF
--- a/src/TurboMqtt/Client/ClientManagerActor.cs
+++ b/src/TurboMqtt/Client/ClientManagerActor.cs
@@ -5,8 +5,6 @@
 // -----------------------------------------------------------------------
 
 using Akka.Actor;
-using TurboMqtt.IO;
-using TurboMqtt.Streams;
 using TurboMqtt.IO.Tcp;
 
 namespace TurboMqtt.Client;

--- a/src/TurboMqtt/Client/ClientStreamOwner.cs
+++ b/src/TurboMqtt/Client/ClientStreamOwner.cs
@@ -23,11 +23,18 @@ namespace TurboMqtt.Client;
 internal sealed class ClientStreamOwner : UntypedActor
 {
     /// <summary>
+    /// Marker interface for all messages that can be sent to the <see cref="ClientStreamOwner"/>
+    /// </summary>
+    public interface IClientStreamOwnerMessage : IDeadLetterSuppression
+    {
+    }
+
+    /// <summary>
     /// Performs a graceful disconnect of the client.
     /// </summary>
-    public sealed record DoDisconnect(CancellationToken CancellationToken) : IDeadLetterSuppression;
+    public sealed record DoDisconnect(CancellationToken CancellationToken) : IClientStreamOwnerMessage;
 
-    public sealed class DisconnectComplete : IDeadLetterSuppression
+    public sealed class DisconnectComplete : IClientStreamOwnerMessage
     {
         public static readonly DisconnectComplete Instance = new();
 
@@ -36,7 +43,7 @@ internal sealed class ClientStreamOwner : UntypedActor
         }
     }
 
-    public sealed class ServerDisconnect : IDeadLetterSuppression
+    public sealed class ServerDisconnect : IClientStreamOwnerMessage
     {
         public ServerDisconnect(DisconnectReasonCode reason)
         {
@@ -46,13 +53,43 @@ internal sealed class ClientStreamOwner : UntypedActor
         public DisconnectReasonCode Reason { get; }
     }
 
-    private sealed class StreamTerminated : IDeadLetterSuppression
+    private sealed class StreamTerminated : IClientStreamOwnerMessage
     {
         private StreamTerminated()
         {
         }
 
         public static readonly StreamTerminated Instance = new();
+    }
+
+    public sealed class TransportConnectedSuccessfully : IClientStreamOwnerMessage
+    {
+        private TransportConnectedSuccessfully()
+        {
+        }
+
+        public static readonly TransportConnectedSuccessfully Instance = new();
+    }
+
+    public sealed class TransportFailedToConnect : IClientStreamOwnerMessage
+    {
+        private TransportFailedToConnect()
+        {
+        }
+
+        public static readonly TransportFailedToConnect Instance = new();
+    }
+
+    /// <summary>
+    /// We've recreated the transport - ready to allow client to attempt to reconnect.
+    /// </summary>
+    public sealed class TransportResetComplete : IClientStreamOwnerMessage
+    {
+        private TransportResetComplete()
+        {
+        }
+
+        public static readonly TransportResetComplete Instance = new();
     }
 
     /// <summary>
@@ -81,6 +118,7 @@ internal sealed class ClientStreamOwner : UntypedActor
     private Dictionary<string, TopicSubscription> _savedSubscriptions = new();
     private int _remainingReconnectAttempts = 3;
     private int _streamOperatorId = 0;
+    private bool _successfullyConnected = false;
 
     protected override void OnReceive(object message)
     {
@@ -126,7 +164,8 @@ internal sealed class ClientStreamOwner : UntypedActor
                             "acks");
                     Context.Watch(_clientAckActor);
 
-                    var heartBeat = new FailureDetector(TimeSpan.FromSeconds(clientConnectOptions.KeepAliveSeconds), Self);
+                    var heartBeat = new FailureDetector(TimeSpan.FromSeconds(clientConnectOptions.KeepAliveSeconds),
+                        Self);
                     _heartBeatActor = Context.ActorOf(
                         Props.Create(() => new HeartBeatActor(outboundPackets, heartBeat)),
                         "heartbeat");
@@ -213,8 +252,32 @@ internal sealed class ClientStreamOwner : UntypedActor
                 break;
             }
 
-            /* Connection handling methods */
+            case TransportConnectedSuccessfully:
+            {
+                // this is used to determine if we should attempt to reconnect
+                _successfullyConnected = true;
+                break;
+            }
 
+            /* Connection handling methods */
+            case TransportFailedToConnect:
+            {
+                var sender = Sender;
+                RunTask(async () =>
+                {
+                    _log.Debug("Client failed to connect to the server. Replacing transport in order to allow reconnect.");
+                    // just to avoid race conditions, unwatch the previous stream instance owner
+                    Context.Unwatch(_streamInstanceOwner);
+                    
+                    _ = _currentTransport?.AbortAsync(); // have to force old resources to close
+                    _currentTransport = null; // null out the old transport
+                    Context.Stop(_streamInstanceOwner); // terminate previous stream
+                    
+                    await ReplaceTransport();
+                    sender.Tell(TransportResetComplete.Instance);
+                });
+                break;
+            }
             case ServerDisconnect serverDisconnect when _remainingReconnectAttempts > 0:
             {
                 _log.Info("Server disconnected the client. Reason: {0}", serverDisconnect.Reason);
@@ -228,12 +291,12 @@ internal sealed class ClientStreamOwner : UntypedActor
             {
                 _log.Info("Server disconnected the client. Reason: {0}", serverDisconnect.Reason);
                 _log.Info("Client has exhausted all reconnect attempts. Shutting down.");
-                Context.Stop(Self); 
+                Context.Stop(Self);
                 break;
             }
 
             // old stream is dead, time to create a new one
-            case StreamTerminated:
+            case StreamTerminated when _successfullyConnected:
             {
                 if (_remainingReconnectAttempts <= 0)
                     return; // ignore
@@ -245,21 +308,15 @@ internal sealed class ClientStreamOwner : UntypedActor
                     // TODO: determine if this is an irrecoverable broker error
                     // if it is, we need to shut down the client
                     // if it's not, we need to reconnect
-                    
-                    CreateStreamInstanceOwner();
 
-                    // time to recreate the transport
-                    _currentTransport = await _transportManager!.CreateTransportAsync();
-
-                    // swap transports
-                    _client!.SwapTransport(_currentTransport);
+                    await ReplaceTransport();
 
                     var requiredActors = new MqttRequiredActors(_exactlyOnceActor!, _atLeastOnceActor!,
                         _clientAckActor!,
                         _heartBeatActor!);
 
                     // need to reconnect the streams
-                    var streamCreateResult = await PrepareStreamAsync(_connectOptions!, _currentTransport,
+                    var streamCreateResult = await PrepareStreamAsync(_connectOptions!, _currentTransport!,
                         _outboundChannel!, _inboundChannel!, requiredActors, Self);
 
                     if (!streamCreateResult.IsSuccess) // should never happen
@@ -353,6 +410,17 @@ internal sealed class ClientStreamOwner : UntypedActor
         }
     }
 
+    private async Task ReplaceTransport()
+    {
+        CreateStreamInstanceOwner();
+
+        // time to recreate the transport
+        _currentTransport = await _transportManager!.CreateTransportAsync();
+
+        // swap transports
+        _client!.SwapTransport(_currentTransport);
+    }
+
     protected override void PostStop()
     {
         // subtle race condition - if someone immediately tries to recreate a failed client, our parent
@@ -360,7 +428,7 @@ internal sealed class ClientStreamOwner : UntypedActor
         // behind the _trueDeath task completion even when it runs only in our PostStop routine.
         // Thus, we're going to front-run DeathWatch here and tell our parent that we're dead.
         Context.Parent.Tell(new ClientManagerActor.ClientDied(_connectOptions!.ClientId));
-        
+
         // force both channels to complete - this will shut down the streams and the transport
         _outboundChannel?.Writer.TryComplete();
         _inboundChannel?.Writer.TryComplete();

--- a/src/TurboMqtt/Client/IMqttClient.cs
+++ b/src/TurboMqtt/Client/IMqttClient.cs
@@ -170,6 +170,7 @@ public sealed class MqttClient : IInternalMqttClient
     void IInternalMqttClient.SwapTransport(IMqttTransport newTransport)
     {
         _transport = newTransport;
+        var a = _transport;
     }
 
     public MqttProtocolVersion ProtocolVersion => _options.ProtocolVersion;

--- a/src/TurboMqtt/IO/InMem/InMemoryMqttTransport.cs
+++ b/src/TurboMqtt/IO/InMem/InMemoryMqttTransport.cs
@@ -86,7 +86,7 @@ internal sealed class InMemoryMqttTransport : IMqttTransport
     
 
 
-    public async Task CloseAsync(CancellationToken ct = default)
+    public async Task<bool> CloseAsync(CancellationToken ct = default)
     {
         Status = ConnectionStatus.Disconnected;
         _writesToTransport.Writer.TryComplete();
@@ -94,6 +94,7 @@ internal sealed class InMemoryMqttTransport : IMqttTransport
         await _shutdownTokenSource.CancelAsync();
         _readsFromTransport.Writer.TryComplete();
         _terminationSource.TrySetResult(DisconnectReasonCode.NormalDisconnection);
+        return true;
     }
 
     public Task AbortAsync(CancellationToken ct = default)
@@ -105,7 +106,7 @@ internal sealed class InMemoryMqttTransport : IMqttTransport
         return Task.CompletedTask;
     }
 
-    public Task ConnectAsync(CancellationToken ct = default)
+    public Task<bool> ConnectAsync(CancellationToken ct = default)
     {
         if (Status == ConnectionStatus.NotStarted)
         {
@@ -116,7 +117,7 @@ internal sealed class InMemoryMqttTransport : IMqttTransport
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
         }
 
-        return Task.CompletedTask;
+        return Task.FromResult(true);
     }
 
     /// <summary>

--- a/src/TurboMqtt/IO/MqttTransport.cs
+++ b/src/TurboMqtt/IO/MqttTransport.cs
@@ -55,7 +55,10 @@ internal interface IMqttTransport
     ///
     /// Also, this method is idempotent - it can be called multiple times without any side effects after the first call.
     /// </remarks>
-    public Task CloseAsync(CancellationToken ct = default);
+    /// <returns>
+    /// <c>true</c> if the disconnect completed gracefully, <c>false</c> otherwise.
+    /// </returns>
+    public Task<bool> CloseAsync(CancellationToken ct = default);
     
     /// <summary>
     /// Force an immediate, unclean shutdown of the transport.
@@ -70,7 +73,10 @@ internal interface IMqttTransport
     /// <remarks>
     /// The connection information is passed into the implementation's constructor, so no need to specify here.
     /// </remarks>
-    public Task ConnectAsync(CancellationToken ct = default);
+    /// <returns>
+    /// <c>true</c> if the connection was successful, <c>false</c> otherwise.
+    /// </returns>
+    public Task<bool> ConnectAsync(CancellationToken ct = default);
     
     /// <summary>
     /// Maximum packet size that can be sent or received over the wire.

--- a/src/TurboMqtt/IO/Tcp/TcpTransport.cs
+++ b/src/TurboMqtt/IO/Tcp/TcpTransport.cs
@@ -69,7 +69,7 @@ internal sealed class TcpTransport : IMqttTransport
     
     public Task WaitForPendingWrites => State.WaitForPendingWrites;
 
-    public Task CloseAsync(CancellationToken ct = default)
+    public Task<bool> CloseAsync(CancellationToken ct = default)
     {
         var watch = _connectionActor.WatchAsync(ct);
          // mark the writer as complete
@@ -85,9 +85,12 @@ internal sealed class TcpTransport : IMqttTransport
         return watch;
     }
 
-    public Task ConnectAsync(CancellationToken ct = default)
+    public async Task<bool> ConnectAsync(CancellationToken ct = default)
     {
-        return _connectionActor.Ask<TcpTransportActor.ConnectResult>(new TcpTransportActor.DoConnect(ct), ct);
+        var result = await _connectionActor.Ask<TcpTransportActor.ConnectResult>(new TcpTransportActor.DoConnect(ct), ct)
+            .ConfigureAwait(false);
+        
+        return result.Status == ConnectionStatus.Connected;
     }
 
     public int MaxFrameSize { get; }

--- a/src/TurboMqtt/IO/Tcp/TcpTransportActor.cs
+++ b/src/TurboMqtt/IO/Tcp/TcpTransportActor.cs
@@ -43,8 +43,11 @@ internal sealed class TcpTransportActor : UntypedActor
             MaxFrameSize = maxFrameSize;
             WaitForPendingWrites = waitForPendingWrites;
         }
+        
+        private volatile ConnectionStatus _status = ConnectionStatus.NotStarted;
 
-        public ConnectionStatus Status { get; set; } = ConnectionStatus.NotStarted;
+        public ConnectionStatus Status { get => _status; 
+            set => _status = value; }
 
         public CancellationTokenSource ShutDownCts { get; set; } = new();
 
@@ -223,11 +226,11 @@ internal sealed class TcpTransportActor : UntypedActor
                     _log.Info("Attempting to connect to [{0}:{1}]", TcpOptions.Host, TcpOptions.Port);
 
                     var sender = Sender;
-
-                    await ResolveAndConnect(connect.Cancel);
-
+                    
                     // set status to connecting
                     State.Status = ConnectionStatus.Connecting;
+
+                    await ResolveAndConnect(connect.Cancel);
                     return;
 
                     // need to resolve DNS to an IP address

--- a/tests/TurboMqtt.Tests/End2End/TcpMqtt311End2EndSpecs.cs
+++ b/tests/TurboMqtt.Tests/End2End/TcpMqtt311End2EndSpecs.cs
@@ -116,13 +116,11 @@ public class TcpMqtt311End2EndSpecs : TransportSpecBase
             MaxReconnectAttempts = 0
         };
         var client = await ClientFactory.CreateTcpClient(DefaultConnectOptions, updatedTcpOptions);
-
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        var connectResult = await client.ConnectAsync(cts.Token);
+        
+        // we are going to do this, intentionally, without a CTS here - this operation MUST FAIL if we are unable to connect
+        var connectResult = await client.ConnectAsync();
         connectResult.IsSuccess.Should().BeFalse();
 
         client.IsConnected.Should().BeFalse();
-        // ReSharper disable once MethodSupportsCancellation
-        await AwaitAssertAsync(() => client.WhenTerminated.IsCompleted.Should().BeTrue());
     }
 }

--- a/tests/TurboMqtt.Tests/End2End/TcpMqtt311End2EndSpecs.cs
+++ b/tests/TurboMqtt.Tests/End2End/TcpMqtt311End2EndSpecs.cs
@@ -119,6 +119,6 @@ public class TcpMqtt311End2EndSpecs : TransportSpecBase
         connectResult.IsSuccess.Should().BeFalse();
 
         client.IsConnected.Should().BeFalse();
-        client.WhenTerminated.IsCompleted.Should().BeTrue();
+        await AwaitAssertAsync(() => client.WhenTerminated.IsCompleted.Should().BeTrue(), cancellationToken: cts.Token);
     }
 }

--- a/tests/TurboMqtt.Tests/End2End/TcpMqtt311End2EndSpecs.cs
+++ b/tests/TurboMqtt.Tests/End2End/TcpMqtt311End2EndSpecs.cs
@@ -111,7 +111,10 @@ public class TcpMqtt311End2EndSpecs : TransportSpecBase
     [Fact]
     public async Task ShouldFailToConnectToNonExistentServer()
     {
-        var updatedTcpOptions = new MqttClientTcpOptions("localhost", 21884);
+        var updatedTcpOptions = new MqttClientTcpOptions("localhost", 21884)
+        {
+            MaxReconnectAttempts = 0
+        };
         var client = await ClientFactory.CreateTcpClient(DefaultConnectOptions, updatedTcpOptions);
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -119,6 +122,7 @@ public class TcpMqtt311End2EndSpecs : TransportSpecBase
         connectResult.IsSuccess.Should().BeFalse();
 
         client.IsConnected.Should().BeFalse();
-        await AwaitAssertAsync(() => client.WhenTerminated.IsCompleted.Should().BeTrue(), cancellationToken: cts.Token);
+        // ReSharper disable once MethodSupportsCancellation
+        await AwaitAssertAsync(() => client.WhenTerminated.IsCompleted.Should().BeTrue());
     }
 }


### PR DESCRIPTION
close #59