### PR TITLE
resolve buffer scaling problems

### DIFF
--- a/benchmarks/TurboMqtt.Benchmarks/Mqtt311/Mqtt311End2EndTcpBenchmarks.cs
+++ b/benchmarks/TurboMqtt.Benchmarks/Mqtt311/Mqtt311End2EndTcpBenchmarks.cs
@@ -62,7 +62,9 @@ public class Mqtt311EndToEndTcpBenchmarks
             _system.Settings.LogFormatter);
         
         // bind to a random port
-        _server = new FakeMqttTcpServer(new MqttTcpServerOptions(Host, 0), MqttProtocolVersion.V3_1_1, loggingAdapter,
+        // set max frame size to 1mb
+        
+        _server = new FakeMqttTcpServer(new MqttTcpServerOptions(Host, 0){ MaxFrameSize = 1024*1024}, MqttProtocolVersion.V3_1_1, loggingAdapter,
             TimeSpan.Zero, new DefaultFakeServerHandleFactory());
         
         _clientFactory = new MqttClientFactory(_system);
@@ -76,7 +78,7 @@ public class Mqtt311EndToEndTcpBenchmarks
         _server.Bind();
         Port = _server.BoundPort;
 
-        _defaultTcpOptions = new MqttClientTcpOptions(Host, Port) { MaxFrameSize = 16 * 1024 };
+        _defaultTcpOptions = new MqttClientTcpOptions(Host, Port) { MaxFrameSize = 256 * 1024 };
         _defaultConnectOptions = new MqttClientConnectOptions("test-subscriber", ProtocolVersion)
         {
             UserName = "testuser",

--- a/benchmarks/TurboMqtt.Benchmarks/Utility/PublishOnlyServerHandler.cs
+++ b/benchmarks/TurboMqtt.Benchmarks/Utility/PublishOnlyServerHandler.cs
@@ -26,12 +26,12 @@ internal sealed class PublishOnlyMqtt311ServerHandler : FakeMqtt311ServerHandle
     {
     }
 
-    public override void TryPush(MqttPacket packet)
+    public override bool TryPush(MqttPacket packet)
     {
         if (packet.PacketType == MqttPacketType.Publish)
-            return; // don't bother writing
+            return false; // don't bother writing
         
-        base.TryPush(packet);
+        return base.TryPush(packet);
     }
 }
 
@@ -43,11 +43,11 @@ internal sealed class ReceiveOnlyMqtt311ServerHandler : FakeMqtt311ServerHandle
     {
     }
 
-    public override void TryPush(MqttPacket packet)
+    public override bool TryPush(MqttPacket packet)
     {
         if (packet.PacketType == MqttPacketType.Publish)
-            return; // don't bother writing
+            return false; // don't bother writing
         
-        base.TryPush(packet);
+        return base.TryPush(packet);
     }
 }

--- a/src/TurboMqtt/IO/FakeServerHandle.cs
+++ b/src/TurboMqtt/IO/FakeServerHandle.cs
@@ -6,7 +6,6 @@
 
 using System.Buffers;
 using Akka.Event;
-using Akka.Streams.Implementation.Fusing;
 using TurboMqtt.PacketTypes;
 using TurboMqtt.Protocol;
 

--- a/src/TurboMqtt/IO/Tcp/FakeMqttTcpServer.cs
+++ b/src/TurboMqtt/IO/Tcp/FakeMqttTcpServer.cs
@@ -210,6 +210,7 @@ internal sealed class FakeMqttTcpServer
                                 : "unknown");
                         break;
                     }
+
                     pipe.Writer.Advance(bytesRead);
 
                     var flushResult = await pipe.Writer.FlushAsync(linkedCts.Token);
@@ -236,6 +237,7 @@ internal sealed class FakeMqttTcpServer
                         handle.WhenClientIdAssigned.IsCompletedSuccessfully
                             ? handle.WhenClientIdAssigned.Result
                             : "unknown");
+                    break;
                 }
             }
 
@@ -250,7 +252,7 @@ internal sealed class FakeMqttTcpServer
             {
                 try
                 {
-                    if (socket.Connected && linkedCts.Token is { CanBeCanceled: true, IsCancellationRequested: false })
+                    if (socket.Connected && linkedCts.Token is { IsCancellationRequested: false })
                     {
                         var sent = socket.Send(msg.buffer.Memory.Span.Slice(0, msg.estimatedSize));
                         while (sent < msg.estimatedSize)

--- a/src/TurboMqtt/IO/Tcp/FakeMqttTcpServer.cs
+++ b/src/TurboMqtt/IO/Tcp/FakeMqttTcpServer.cs
@@ -73,8 +73,8 @@ internal sealed class FakeMqttTcpServer
         {
             _bindSocket = new Socket(SocketType.Stream, ProtocolType.Tcp)
             {
-                ReceiveBufferSize = _options.MaxFrameSize * 2,
-                SendBufferSize = _options.MaxFrameSize * 2,
+                ReceiveBufferSize = TcpTransportActor.ScaleBufferSize(_options.MaxFrameSize),
+                SendBufferSize = TcpTransportActor.ScaleBufferSize(_options.MaxFrameSize),
                 DualMode = true,
                 NoDelay = true,
                 LingerState = new LingerOption(false, 0)
@@ -84,8 +84,8 @@ internal sealed class FakeMqttTcpServer
         {
             _bindSocket = new Socket(_options.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
             {
-                ReceiveBufferSize = _options.MaxFrameSize * 2,
-                SendBufferSize = _options.MaxFrameSize * 2,
+                ReceiveBufferSize = TcpTransportActor.ScaleBufferSize(_options.MaxFrameSize),
+                SendBufferSize = TcpTransportActor.ScaleBufferSize(_options.MaxFrameSize),
                 DualMode = true,
                 NoDelay = true,
                 LingerState = new LingerOption(false, 0)

--- a/src/TurboMqtt/IO/Tcp/TcpTransportActor.cs
+++ b/src/TurboMqtt/IO/Tcp/TcpTransportActor.cs
@@ -322,7 +322,7 @@ internal sealed class TcpTransportActor : UntypedActor
                     try
                     {
                         var workingBuffer = buffer.Memory;
-                        while (readableBytes > 0 && _tcpClient != null) // so we can avoid NREs on shutdown
+                        while (readableBytes > 0 && _tcpClient is { Connected: true })
                         {
                             var sent = await _tcpClient!.SendAsync(workingBuffer.Slice(0, readableBytes), ct)
                                 .ConfigureAwait(false);

--- a/src/TurboMqtt/IO/Tcp/TcpTransportActor.cs
+++ b/src/TurboMqtt/IO/Tcp/TcpTransportActor.cs
@@ -141,8 +141,6 @@ internal sealed class TcpTransportActor : UntypedActor
      * Running --> DoWriteToPipeAsync --> Running (read data from socket) --> DoWriteToSocketAsync --> Running (write data to socket)
      */
     
-    private const int ScalingFactor = 6;
-
     /// <summary>
     /// Performs the max buffer size scaling for the socket.
     /// </summary>
@@ -324,7 +322,7 @@ internal sealed class TcpTransportActor : UntypedActor
                     try
                     {
                         var workingBuffer = buffer.Memory;
-                        while (readableBytes > 0)
+                        while (readableBytes > 0 && _tcpClient != null) // so we can avoid NREs on shutdown
                         {
                             var sent = await _tcpClient!.SendAsync(workingBuffer.Slice(0, readableBytes), ct)
                                 .ConfigureAwait(false);


### PR DESCRIPTION
Realized our benchmarks were dying with larger message sizes due to [ResumeWriterThreshold](https://learn.microsoft.com/en-us/dotnet/api/system.io.pipelines.pipeoptions.resumewriterthreshold?view=net-8.0#system-io-pipelines-pipeoptions-resumewriterthreshold) being set while still only having a partial frame. Working on debugging this.