### PR TITLE
simplify End2End TCP benchmarks

### DIFF
--- a/benchmarks/TurboMqtt.Benchmarks/Mqtt311/Mqtt311End2EndTcpBenchmarks.cs
+++ b/benchmarks/TurboMqtt.Benchmarks/Mqtt311/Mqtt311End2EndTcpBenchmarks.cs
@@ -24,7 +24,7 @@ public class Mqtt311EndToEndTcpBenchmarks
 
     [Params(MqttProtocolVersion.V3_1_1)] public MqttProtocolVersion ProtocolVersion { get; set; }
 
-    public const int PacketCount = 10_000;
+    public const int PacketCount = 1_000;
 
     private ActorSystem? _system;
     private IMqttClientFactory? _clientFactory;
@@ -35,7 +35,8 @@ public class Mqtt311EndToEndTcpBenchmarks
     private MqttClientConnectOptions? _defaultConnectOptions;
     private MqttClientTcpOptions? _defaultTcpOptions;
 
-    private const string Topic = "test";
+    private const string TopicConst = "test";
+    private string Topic = TopicConst;
     private const string Host = "localhost";
     private const int Port = 1883;
     
@@ -59,13 +60,6 @@ public class Mqtt311EndToEndTcpBenchmarks
         _system = ActorSystem.Create("Mqtt311EndToEndTcpBenchmarks", "akka.loglevel=ERROR");
         
         _clientFactory = new MqttClientFactory(_system);
-        _testMessage = new MqttMessage(Topic, CreateMsgPayload())
-        {
-            PayloadFormatIndicator = PayloadFormatIndicator.Unspecified,
-            ContentType = "application/binary",
-            QoS = QoSLevel
-        };
-
         _defaultTcpOptions = new MqttClientTcpOptions(Host, Port) { MaxFrameSize = 256 * 1024 };
     }
     
@@ -79,6 +73,7 @@ public class Mqtt311EndToEndTcpBenchmarks
     [IterationSetup]
     public void SetupPerIteration()
     {
+        Topic = TopicConst + Guid.NewGuid();
         _defaultConnectOptions = new MqttClientConnectOptions("test-subscriber" + Guid.NewGuid(), ProtocolVersion)
         {
             UserName = "admin",
@@ -87,6 +82,14 @@ public class Mqtt311EndToEndTcpBenchmarks
             MaxReconnectAttempts = 3,
             PublishRetryInterval = TimeSpan.FromSeconds(5)
         };
+        
+        _testMessage = new MqttMessage(Topic, CreateMsgPayload())
+        {
+            PayloadFormatIndicator = PayloadFormatIndicator.Unspecified,
+            ContentType = "application/binary",
+            QoS = QoSLevel
+        };
+
         
         _writeTasks.Clear();
         DoSetup().Wait();
@@ -150,11 +153,13 @@ public class Mqtt311EndToEndTcpBenchmarks
 
         async Task<int> WriteMessages(CancellationToken ct)
         {
-            for (var i = 0; i < PacketCount; i += ChunkSize)
+            var tasks = new List<Task>(PacketCount);
+            for (var i = 0; i < PacketCount; i++)
             {
-                var tasks = Enumerable.Range(0, ChunkSize).Select(c => _subscribeClient!.PublishAsync(_testMessage!, cts.Token));
-                await Task.WhenAll(tasks).WaitAsync(ct);
+                tasks.Add(_subscribeClient!.PublishAsync(_testMessage!, ct));
             }
+            
+            await Task.WhenAll(tasks);
             
             return 0;
         }

--- a/benchmarks/TurboMqtt.Benchmarks/Mqtt311/Mqtt311End2EndTcpBenchmarks.cs
+++ b/benchmarks/TurboMqtt.Benchmarks/Mqtt311/Mqtt311End2EndTcpBenchmarks.cs
@@ -132,7 +132,7 @@ public class Mqtt311EndToEndTcpBenchmarks
     [Benchmark(OperationsPerInvoke = PacketCount * 2)]
     public async Task<int> PublishAndReceiveMessages()
     {
-        using var cts = new CancellationTokenSource(System.TimeSpan.FromMinutes(2));
+        using var cts = new CancellationTokenSource(System.TimeSpan.FromSeconds(30));
 
         var writes = WriteMessages(cts.Token);
 

--- a/benchmarks/TurboMqtt.Benchmarks/Mqtt311/Mqtt311End2EndTcpBenchmarks.cs
+++ b/benchmarks/TurboMqtt.Benchmarks/Mqtt311/Mqtt311End2EndTcpBenchmarks.cs
@@ -20,11 +20,11 @@ public class Mqtt311EndToEndTcpBenchmarks
     [Params(QualityOfService.AtMostOnce, QualityOfService.AtLeastOnce, QualityOfService.ExactlyOnce)]
     public QualityOfService QoSLevel { get; set; }
 
-    [Params(10, 1024, 2 * 1024)] public int PayloadSizeBytes { get; set; }
+    [Params(10)] public int PayloadSizeBytes { get; set; }
 
     [Params(MqttProtocolVersion.V3_1_1)] public MqttProtocolVersion ProtocolVersion { get; set; }
 
-    public const int PacketCount = 100_00;
+    public const int PacketCount = 10_000;
 
     private ActorSystem? _system;
     private IMqttClientFactory? _clientFactory;

--- a/src/TurboMqtt/Streams/ClientAckingFlow.cs
+++ b/src/TurboMqtt/Streams/ClientAckingFlow.cs
@@ -61,6 +61,7 @@ internal sealed class ClientAckingFlow : GraphStage<FlowShape<MqttPacket, MqttPa
         private readonly SimpleLruCache<NonZeroUInt16> _publishIds;
         private readonly SimpleLruCache<NonZeroUInt16> _pubRelIds;
         private readonly ClientAckingFlow _stage;
+        private readonly Queue<MqttPacket> _buffer = new();
         
         // just to stop us from logging multiple Disconnect messages
         private bool _shutdownTriggered;
@@ -80,6 +81,9 @@ internal sealed class ClientAckingFlow : GraphStage<FlowShape<MqttPacket, MqttPa
         public void OnPush()
         {
             var packet = Grab(_stage.In);
+            // need to do this to ensure that we don't block the stream
+            Pull(_stage.In);
+            
             Log.Debug("Received packet of type [{0}] from client.", packet.PacketType);
             
             if(packet.PacketType == MqttPacketType.Publish)
@@ -88,9 +92,6 @@ internal sealed class ClientAckingFlow : GraphStage<FlowShape<MqttPacket, MqttPa
                 HandlePublish(publish);
                 return;
             }
-            
-            // need to do this to ensure that we don't block the stream
-            Pull(_stage.In);
 
             switch (packet.PacketType)
             {
@@ -145,6 +146,27 @@ internal sealed class ClientAckingFlow : GraphStage<FlowShape<MqttPacket, MqttPa
                     throw new ArgumentOutOfRangeException(nameof(packet), $"Unsupported packet of type [{packet.PacketType}] - this is a server message.");
             }
         }
+        
+        private bool TryPush(MqttPacket packet)
+        {
+            // if Port is available, push the packet
+            if (IsAvailable(_stage.Out))
+            {
+                if (_buffer.TryDequeue(out var olderPacket))
+                {
+                    Push(_stage.Out, olderPacket);
+                    _buffer.Enqueue(packet);
+                }
+                else
+                    Push(_stage.Out, packet);
+                return true;
+            }
+            else 
+            {
+                _buffer.Enqueue(packet);
+                return false;
+            }
+        }
 
         public override void PreStart()
         {
@@ -163,9 +185,21 @@ internal sealed class ClientAckingFlow : GraphStage<FlowShape<MqttPacket, MqttPa
             FailStage(e);
         }
 
+        public override void PostStop()
+        {
+            // clean up any remaining packets
+            Log.Info("Cleaning up remaining [{0}] packets in buffer.", _buffer.Count);
+            _buffer.Clear();
+        }
+
         public void OnPull()
         {
-            Pull(_stage.In);
+            if(_buffer.TryDequeue(out var packet)) // immediately push the next packet if we have one
+                Push(_stage.Out, packet);
+            else
+                // if we don't have any packets to push, pull from the upstream
+                // to see if we can get more (this is a backpressure mechanism
+                Pull(_stage.In);
         }
 
         public void OnDownstreamFinish(Exception cause)
@@ -179,7 +213,7 @@ internal sealed class ClientAckingFlow : GraphStage<FlowShape<MqttPacket, MqttPa
             switch (publish.QualityOfService)
             {
                 case QualityOfService.AtMostOnce:
-                    Push(_stage.Out, publish); // no ACK required here
+                    TryPush(publish); // no ACK required here
                     return;
                 case QualityOfService.AtLeastOnce:
                 case QualityOfService.ExactlyOnce:
@@ -193,7 +227,7 @@ internal sealed class ClientAckingFlow : GraphStage<FlowShape<MqttPacket, MqttPa
 
                     if (alreadySeen) return; // add the PacketId and push the message if we've never seen it before
                     _publishIds.Add(publish.PacketId);
-                    Push(_stage.Out, publish);
+                    TryPush(publish);
                     return;
                 }
                 default:

--- a/src/TurboMqtt/Streams/ClientAckingFlow.cs
+++ b/src/TurboMqtt/Streams/ClientAckingFlow.cs
@@ -81,9 +81,6 @@ internal sealed class ClientAckingFlow : GraphStage<FlowShape<MqttPacket, MqttPa
         public void OnPush()
         {
             var packet = Grab(_stage.In);
-            // need to do this to ensure that we don't block the stream
-            Pull(_stage.In);
-            
             Log.Debug("Received packet of type [{0}] from client.", packet.PacketType);
             
             if(packet.PacketType == MqttPacketType.Publish)
@@ -92,6 +89,9 @@ internal sealed class ClientAckingFlow : GraphStage<FlowShape<MqttPacket, MqttPa
                 HandlePublish(publish);
                 return;
             }
+            
+            // need to do this to ensure that we don't block the stream
+            Pull(_stage.In);
 
             switch (packet.PacketType)
             {

--- a/tests/TestContainers.TurboMqtt/TestContainers.TurboMqtt.csproj
+++ b/tests/TestContainers.TurboMqtt/TestContainers.TurboMqtt.csproj
@@ -6,6 +6,7 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <RootNamespace>TestContainers</RootNamespace>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Use just the smaller message sizes so we stop blowing up EMQX 