### PR TITLE
added v0.1.0 release notes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,9 +3,13 @@
     <Copyright>Copyright © 2024 Petabridge, LLC</Copyright>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.1.0-beta2</VersionPrefix>
+    <VersionPrefix>0.1.0</VersionPrefix>
     <Authors>Petabridge</Authors>
-    <PackageReleaseNotes>First release; fully-functioning MQTT 3.1.1 client over TCP, but we're missing TLS support still.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fully functioning MQTT 3.1.1 support without TLS. Hitting 160k msg/s in our benchmarks on QoS=0 - see [TurboMqtt Performance](https://github.com/petabridge/TurboMqtt/blob/dev/docs/Performance.md) for details.
+
+Fixed some client resiliency problems, protecting against broker disconnect and failure scenarios with clean automatic restarts.
+
+Upgraded to [Akka.NET 1.5.20](https://github.com/akkadotnet/akka.net/releases/tag/1.5.20).</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Label="Build">
     <LangVersion>latest</LangVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
-#### 0.1.0-beta3 April 26th 2024 ####
+#### 0.1.0 May 1st 2024 ####
 
-First release; fully-functioning MQTT 3.1.1 client over TCP, but we're missing TLS support still.
+Fully functioning MQTT 3.1.1 support without TLS. Hitting 160k msg/s in our benchmarks on QoS=0 - see [TurboMqtt Performance](https://github.com/petabridge/TurboMqtt/blob/dev/docs/Performance.md) for details.
+
+Fixed some client resiliency problems, protecting against broker disconnect and failure scenarios with clean automatic restarts.
+
+Upgraded to [Akka.NET 1.5.20](https://github.com/akkadotnet/akka.net/releases/tag/1.5.20).


### PR DESCRIPTION
#### 0.1.0 May 1st 2024 ####

Fully functioning MQTT 3.1.1 support without TLS. Hitting 160k msg/s in our benchmarks on QoS=0 - see [TurboMqtt Performance](https://github.com/petabridge/TurboMqtt/blob/dev/docs/Performance.md) for details.

Fixed some client resiliency problems, protecting against broker disconnect and failure scenarios with clean automatic restarts.

Upgraded to [Akka.NET 1.5.20](https://github.com/akkadotnet/akka.net/releases/tag/1.5.20).