### PR TITLE
Add agent constitution, project context, and tooling docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,42 @@ All code must compile with zero warnings (`TreatWarningsAsErrors` is on).
 - `build.ps1` extracts version + notes and patches Directory.Build.props
 - Releases are triggered by pushing a git tag; GitHub Actions handles signing and publishing (migration from Azure DevOps tracked in #326)
 
+## Skills Index
+
+Use these skills by name when the task matches. Invoke with `/skill-name`.
+Skills prefixed with `dotnet-skills:` come from the [petabridge/dotnet-skills](https://github.com/petabridge/dotnet-skills) marketplace. If a skill is not installed, add it via Claude Code's `/install-skill` or the dotnet-skills README.
+
+### Akka.NET & Architecture
+`akka-best-practices` actors, supervision, error handling, work distribution
+`akka-testing-patterns` Akka.Hosting.TestKit, TestProbes, persistence testing
+`analyze-racy-test` flaky tests, race conditions, timing-dependent failures
+
+### C# & API Design
+`csharp-coding-standards` records, pattern matching, Span/Memory, async/await
+`csharp-concurrency-patterns` Channels, async, choosing concurrency abstractions
+`csharp-api-design` public API compat, versioning, extend-only design
+`csharp-type-design-performance` sealed classes, readonly structs, collection choices
+
+### Performance & Benchmarking
+`create-benchmark` design new BenchmarkDotNet benchmarks
+`run-benchmark` execute benchmarks and capture results
+`analyze-performance` analyze benchmark results, profiler data, regressions
+`benchmark-workflow` coordinated run + analyze workflow
+
+### Testing & Quality
+`testcontainers` E2E tests with real brokers in Docker
+`crap-analysis` code coverage + CRAP score risk hotspots
+`slopwatch` detect reward hacking in code changes
+
+### Project & Packages
+`project-structure` Directory.Build.props, CPM, SourceLink, versioning
+`package-management` NuGet CPM, dotnet add/remove/list
+
+### PR & Release
+`check-api-breaking` API breaking change detection
+`review-pr` comprehensive pull request review
+`create-release` release notes, git tags, publish workflow
+
 ## Continuous Improvement
 
 - If a workflow is repeated 3+ times, extract it into a repo skill or script

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# TurboMqtt Agent Constitution
+
+TurboMqtt is a high-performance, streaming-first MQTT client library for .NET built on Akka.NET and Akka.Streams. The goal is to be the fastest MQTT client in the .NET ecosystem.
+
+See [PROJECT_CONTEXT.md](PROJECT_CONTEXT.md) for architecture, roadmap, and current state.
+See [TOOLING.md](TOOLING.md) for build, test, benchmark, and CI/CD instructions.
+
+## Task Routing
+
+Before acting, identify the work mode:
+
+| Mode | Signals | Outputs |
+|------|---------|---------|
+| **Engineering** | Code in `src/`, `tests/`, `benchmarks/`, `samples/`; bugs; features; performance | Code + tests; benchmarks for perf work |
+| **Release** | Version bumps, RELEASE_NOTES.md, tags, publishing | Updated version, release notes, tag |
+
+## Build and Test
+
+```bash
+# Build
+dotnet build -c Release
+
+# Test (unit + integration, no Docker)
+dotnet test tests/TurboMqtt.Tests/ -c Release
+
+# Test (E2E with real broker, requires Docker)
+dotnet test tests/TurboMqtt.Container.Tests/ -c Release
+
+# Pack
+dotnet pack -c Release
+```
+
+All code must compile with zero warnings (`TreatWarningsAsErrors` is on).
+
+## Quality Bar
+
+### All Code Changes
+
+- Tests pass on both Linux and Windows
+- No new compiler warnings
+- Property-based tests (FsCheck) for any codec or protocol logic
+- Akka.Hosting.TestKit for actor behavior tests
+
+### Performance-Sensitive Changes
+
+- Run relevant BenchmarkDotNet benchmarks before and after
+- No throughput regressions on the MQTT 3.1.1 pipeline
+- Prefer zero-allocation patterns: `ReadOnlyMemory<byte>`, `Span<T>`, `MemoryPool<byte>`, `IMemoryOwner<byte>`
+- Use `System.Threading.Channels` over locks for concurrency
+- Batch operations where possible (see `BatchWeighted` in encoding flows)
+
+### Protocol Changes
+
+- Validate against real brokers via container tests (EMQX)
+- Cover all three QoS levels (0, 1, 2)
+- Test partial frame handling and packet boundary edge cases
+
+## Coding Conventions
+
+- File-scoped namespaces, implicit usings, nullable reference types enabled
+- C# latest language version
+- Central Package Management: use `dotnet add package` (never edit csproj/props XML directly)
+- Akka.NET actors use `ReceiveActor` or `UntypedActor` patterns; hosting via `Akka.Hosting`
+- Internal types exposed to test projects via `InternalsVisibleTo` in `Properties/Friends.cs`
+
+## Key Architectural Rules
+
+- **Akka.NET is the concurrency model.** Do not introduce raw `Task.Run`, `Thread`, or manual synchronization unless there is no actor-based alternative.
+- **Akka.Streams is the data pipeline.** Encode, decode, and receive flows are stream stages. Do not bypass streams for packet processing.
+- **Channels bridge actors to user code.** `System.Threading.Channels` is the public-facing async interface; actors and streams are internal.
+- **Memory is pooled.** Use `MemoryPool<byte>` for buffers. Dispose `IMemoryOwner<byte>` when done. Never copy payload bytes unnecessarily.
+
+## Versioning and Releases
+
+- Version is in `Directory.Build.props` (`VersionPrefix`)
+- Release notes go in `RELEASE_NOTES.md` using `#### VERSION DATE ####` format
+- `build.ps1` extracts version + notes and patches Directory.Build.props
+- Releases are triggered by pushing a git tag; GitHub Actions handles signing and publishing (migration from Azure DevOps tracked in #326)
+
+## Continuous Improvement
+
+- If a workflow is repeated 3+ times, extract it into a repo skill or script
+- Volatile project knowledge belongs in `PROJECT_CONTEXT.md` or `TOOLING.md`, not here
+- This file should remain compact and stable; update only for governance changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ All code must compile with zero warnings (`TreatWarningsAsErrors` is on).
 ## Skills Index
 
 Use these skills by name when the task matches. Invoke with `/skill-name`.
-Skills prefixed with `dotnet-skills:` come from the [petabridge/dotnet-skills](https://github.com/petabridge/dotnet-skills) marketplace. If a skill is not installed, add it via Claude Code's `/install-skill` or the dotnet-skills README.
+Skills prefixed with `dotnet-skills:` come from the [Aaronontheweb/dotnet-skills](https://github.com/Aaronontheweb/dotnet-skills) marketplace. If a skill is not installed, add it via Claude Code's `/install-skill` or the dotnet-skills README.
 
 ### Akka.NET & Architecture
 `akka-best-practices` actors, supervision, error handling, work distribution

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -1,0 +1,84 @@
+# Project Context
+
+## What Is TurboMqtt
+
+TurboMqtt is a high-performance MQTT client library for .NET, built on Akka.NET and Akka.Streams. It aims to be the **fastest, most resource-efficient MQTT client in the .NET ecosystem** - a streaming-first solution for large-scale IoT workloads.
+
+Published as a NuGet package under Apache 2.0 by [Petabridge](https://petabridge.com/).
+
+## Who It's For
+
+.NET developers building IoT applications that need:
+
+- 100k+ msg/s throughput from a single client
+- Backpressure-aware message consumption via `System.Threading.Channels`
+- Automatic QoS 1/2 acknowledgment and retry
+- OpenTelemetry observability out of the box
+- Fault-tolerant connections via Akka.NET supervision
+
+## Architecture
+
+### Core Stack
+
+- **Akka.NET actors** for connection lifecycle, heartbeat, ACK tracking, and publish retries
+- **Akka.Streams** for encode/decode/receive pipelines with `BatchWeighted` frame packing
+- **System.Threading.Channels** for lock-free producer/consumer bridging to user code
+- **System.Buffers.MemoryPool\<byte\>** for pooled memory allocation; `ReadOnlyMemory<byte>` payloads
+
+### Actor Hierarchy
+
+```
+ActorSystem
+├── turbomqtt-clients (ClientManagerActor)
+│   ├── tcp (TcpConnectionManager)
+│   │   └── tcp-transport-N (TcpTransportActor)
+│   └── mqttclient-{clientId}-N (ClientStreamOwner)
+│       ├── heartbeat (HeartBeatActor)
+│       ├── acks (ClientAcksActor)
+│       ├── publish-qos1 (AtLeastOncePublishRetryActor)
+│       ├── publish-qos2 (ExactlyOncePublishRetryActor)
+│       └── stream (ClientStreamInstance)
+```
+
+### Protocol Support
+
+| Protocol | Status |
+|----------|--------|
+| MQTT 3.1.1 | Implemented (production hardening in progress) |
+| MQTT 5.0 | Packet infrastructure exists; not yet functional |
+| MQTT over QUIC | Roadmap only |
+| TLS | In-flight (draft PRs #123, #182) |
+
+### Key Constraints
+
+- Akka.NET is a core architectural dependency
+- AOT compatibility is a longer-term goal, blocked on Akka.NET v1.6
+- `TreatWarningsAsErrors` is enabled globally
+- `AllowUnsafeBlocks` is enabled for performance-critical code paths
+- Single NuGet package target: `net8.0`
+
+## Current State
+
+- **Version**: 0.2.0 (pre-1.0, last release June 2024)
+- **Priority**: MQTT 3.1.1 production readiness (epic #66)
+- **Known issues**: CI/CD GitHub Release broken (#74), flaky test (#99), dependabot PR backlog
+- **In-flight features**: TLS support, AOT canary, decoder perf optimization
+
+## Roadmap
+
+1. MQTT 3.1.1 production readiness (current)
+2. MQTT 5.0 support (epic #67)
+3. MQTT over QUIC (epic #68)
+
+## Repository Layout
+
+```
+src/TurboMqtt/           # Core library
+tests/TurboMqtt.Tests/   # Unit + integration tests (xUnit, FsCheck, Akka.Hosting.TestKit)
+tests/TurboMqtt.Container.Tests/  # E2E tests against real brokers via TestContainers
+tests/TestContainers.TurboMqtt/   # Custom TestContainers for EMQX
+benchmarks/TurboMqtt.Benchmarks/  # BenchmarkDotNet performance tests
+samples/                 # DevNullConsumer, BackpressureProducer
+scripts/                 # Build, version bump, signing scripts
+docs/                    # Performance docs, telemetry docs
+```

--- a/TOOLING.md
+++ b/TOOLING.md
@@ -1,0 +1,65 @@
+# Tooling
+
+## Build
+
+| Tool | Version | Access | Purpose |
+|------|---------|--------|---------|
+| .NET SDK | 8.0.400 (pinned in `global.json`, rollForward: latestMinor) | `dotnet` | Build, test, pack |
+| `build.ps1` | - | `pwsh build.ps1` | Extracts version + release notes from RELEASE_NOTES.md, updates Directory.Build.props |
+| `SignClient` | 1.2.109 | Local tool (`.config/dotnet-tools.json`) | NuGet package code signing (**deprecated** - migrating to `dotnet sign`, see #326) |
+
+## Package Management
+
+- **Central Package Management** via `Directory.Packages.props`
+- **Shared build properties** via `Directory.Build.props`
+- **NuGet source**: nuget.org only (`nuget.config` with package source mapping)
+- Use `dotnet add/remove/list package` commands; do not edit XML directly
+
+## Testing
+
+| Tool | Purpose | Notes |
+|------|---------|-------|
+| xUnit 2.9.2 | Test framework | All test projects |
+| Akka.Hosting.TestKit | Actor testing | For actor-based specs |
+| FsCheck 2.16.6 | Property-based testing | Codec fuzzing |
+| FluentAssertions 6.12.1 | Assertions | |
+| TestContainers 4.1.0 | Container-based E2E tests | EMQX, NanoMQ brokers |
+| Coverlet 6.0.3 | Code coverage collection | XPlat format in CI |
+
+### Running Tests
+
+```bash
+# Unit + integration tests (no Docker required)
+dotnet test tests/TurboMqtt.Tests/
+
+# Container-based E2E tests (requires Docker)
+dotnet test tests/TurboMqtt.Container.Tests/
+```
+
+## Benchmarking
+
+| Tool | Purpose |
+|------|---------|
+| BenchmarkDotNet 0.14.0 | Performance measurement |
+| `start-emqx.ps1` | Start EMQX Docker container for E2E benchmarks |
+| `stop-eqmx.ps1` | Stop EMQX container |
+
+```bash
+# Run benchmarks (EMQX must be running for E2E benchmarks)
+dotnet run -c Release --project benchmarks/TurboMqtt.Benchmarks/
+```
+
+## CI/CD
+
+| System | Trigger | Purpose |
+|--------|---------|---------|
+| GitHub Actions (`pr_validation.yaml`) | Push / PR to dev, main, master | Build + test (Ubuntu + Windows), code coverage |
+| Azure DevOps (`build_release.yaml`) | Git tag push | **Being replaced** by GitHub Actions (see #326) |
+| Dependabot | Daily at 11:00 UTC | NuGet + GitHub Actions dependency updates |
+
+## Source Control
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| GitHub CLI | 2.76.1 | Issues, PRs, releases, API |
+| Docker | 28.3.3 | EMQX/NanoMQ broker containers |

--- a/TOOLING.md
+++ b/TOOLING.md
@@ -1,5 +1,10 @@
 # Tooling
 
+## Repository
+
+- **Upstream**: [petabridge/TurboMqtt](https://github.com/petabridge/TurboMqtt) - PRs always target this repo's `dev` branch
+- **Default branch**: `dev`
+
 ## Build
 
 | Tool | Version | Access | Purpose |


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Agent constitution defining task routing (engineering/release), build commands, quality bar, coding conventions, architectural rules, versioning workflow, and a compressed skills index referencing relevant [dotnet-skills](https://github.com/Aaronontheweb/dotnet-skills) marketplace skills
- **PROJECT_CONTEXT.md**: Mutable project knowledge - architecture overview, actor hierarchy, protocol support matrix, constraints, current state, and roadmap
- **TOOLING.md**: Build, test, benchmark, and CI/CD tooling inventory with version pins and access notes
- **AGENTS.md**: Symlink to CLAUDE.md for harness compatibility

## Test plan

- [ ] Verify AGENTS.md symlink resolves correctly after clone
- [ ] Confirm no build or test impact (documentation-only change)