### PR TITLE
Add transport layer redesign PRD and Phase 2.5 implementation plan

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -249,23 +249,14 @@ Done when:
 - [ ] No `[Skip]` attribute or equivalent workaround -- the test runs normally
 - [ ] Issue #99 can be closed
 
-### Task 2.7: Evaluate and integrate TLS support
+### Task 2.7: TLS support
 
-**PRD:** TLS support (draft PRs referenced in PROJECT_CONTEXT.md, in-flight on `tls-support2` branch)
-**Surface area:** cross-cutting
-**Verification:** L2
-
-TLS support exists in-flight on the `tls-support2` branch. Evaluate the state of
-that branch, determine if it can be merged to `dev` or needs rewriting, and integrate it.
+**Replaced by Phase 2.5-C** (Transport Layer Redesign). The `tls-support2` branch approach
+is superseded by the `IStreamProvider` + `TlsStreamProvider` design in Phase 2.5. See
+[docs/prd/transport-redesign/README.md](docs/prd/transport-redesign/README.md) for rationale.
 
 Done when:
-- [ ] `tls-support2` branch code reviewed for correctness and compatibility with current `dev`
-- [ ] Decision documented: merge as-is, merge with modifications, or rewrite
-- [ ] TLS transport integrated into `dev` branch (either via merge or new implementation)
-- [ ] `MqttClientConnectOptions` (or equivalent) supports TLS configuration (certificate, server name, skip validation for testing)
-- [ ] Container test exists that connects to EMQX over TLS (port 8883) and publishes/subscribes at QoS 0 and QoS 1
-- [ ] Unit tests cover TLS option validation (e.g., TLS required but no certificate configured)
-- [ ] `PROJECT_CONTEXT.md` protocol support table updated: TLS status changed from "In-flight" to "Implemented"
+- [x] Superseded by Phase 2.5-C — no action needed in Phase 2
 
 ### Task 2.8: Add MQTT 3.1.1 E2E tests with authentication enabled
 
@@ -285,6 +276,118 @@ Done when:
 
 ---
 
+## Phase 2.5: Transport Layer Redesign
+
+> Goal: Fix 12+ race conditions in the transport/lifecycle layer, eliminate GC pressure
+> from unpooled read allocations, introduce a `Stream` abstraction to enable TLS, and
+> formalize the transport actor state machine. This must happen before MQTT 5.0 because
+> the transport layer needs to be solid before adding protocol complexity.
+>
+> **PRD:** [docs/prd/transport-redesign/README.md](docs/prd/transport-redesign/README.md)
+>
+> **Prerequisites:** Phase 2 tasks 2.1-2.6 should be complete (codec hardening provides
+> the test infrastructure to verify transport changes don't regress behavior).
+
+### Task 2.5-A: Extract Stream abstraction and pool read allocations
+
+**PRD:** [docs/prd/transport-redesign/README.md](docs/prd/transport-redesign/README.md) §4, §8
+**Surface area:** cross-cutting
+**Verification:** L2
+
+Introduce `IStreamProvider` + `TcpStreamProvider`, refactor `TcpTransportActor` to use
+`Stream.ReadAsync`/`Stream.WriteAsync` instead of `Socket.ReceiveAsync`/`Socket.SendAsync`,
+and replace `new byte[]` allocations in `ReadFromPipeAsync` with `MemoryPool<byte>.Shared.Rent()`.
+
+Done when:
+- [ ] `IStreamProvider` interface exists in `src/TurboMqtt/IO/Tcp/IStreamProvider.cs`
+- [ ] `TcpStreamProvider` implementation exists in `src/TurboMqtt/IO/Tcp/TcpStreamProvider.cs`
+- [ ] `TcpStreamProvider.ConnectAsync()` creates Socket, resolves DNS, connects, returns `NetworkStream`
+- [ ] `TcpTransportActor` constructor takes `IStreamProvider` instead of creating Socket directly
+- [ ] `DoWriteToPipeAsync` reads from `Stream.ReadAsync()` instead of `Socket.ReceiveAsync()`
+- [ ] `DoWriteToSocketAsync` writes to `Stream.WriteAsync()` instead of `Socket.SendAsync()`
+- [ ] `ReadFromPipeAsync` uses `MemoryPool<byte>.Shared.Rent()` instead of `new byte[buffer.Length]`
+- [ ] `UnsharedMemoryOwner` no longer used on the read path (may still be used elsewhere)
+- [ ] `TcpTransport.cs` updated to pass `IStreamProvider` through
+- [ ] `TcpConnectionManager.cs` updated to create appropriate `IStreamProvider`
+- [ ] All existing TCP unit tests pass unchanged
+- [ ] All container tests pass against EMQX
+- [ ] New unit tests for `TcpStreamProvider` (connect, DNS resolution, socket configuration)
+- [ ] BenchmarkDotNet before/after confirms no throughput regression (baseline: 193k msg/sec QoS 0)
+- [ ] Builds with zero warnings
+
+### Task 2.5-B: Fix transport race conditions
+
+**PRD:** [docs/prd/transport-redesign/README.md](docs/prd/transport-redesign/README.md) §1.2, §5, §6
+**Surface area:** cross-cutting
+**Verification:** L2
+
+Fix the 12+ identified race conditions in shutdown, reconnection, and transport swap.
+Can be developed in parallel with Task 2.5-A.
+
+Done when:
+- [ ] `TcpTransportActor` uses explicit `Become` states: `NotStarted → Created → Connecting → Connected → Draining → Closing → Stopped` (and `Aborted` short-circuit)
+- [ ] Background tasks in `BecomeRunning()` tracked with `Task.WhenAll` + `ContinueWith` self-tell `BackgroundTasksCompleted`
+- [ ] `CleanUpGracefully` replaced with state-driven transitions — no more fire-and-forget async
+- [ ] Duplicate `DoClose`/`ReadFinished`/`ConnectionUnexpectedlyClosed` messages in non-handling states are ignored
+- [ ] `MqttClient.SwapTransport()` uses `Interlocked.Exchange` + `volatile` field
+- [ ] TOCTOU on `IsConnected` in `PublishAsync` eliminated — rely on `TryWrite` returning false
+- [ ] `ClientStreamOwner.PostStop()` follows deterministic ordering: complete outbound → abort transport → complete inbound → signal death
+- [ ] `ClientStreamOwner` reconnect uses message-driven `Reconnecting` behavior (no fire-and-forget `DoReconnect`)
+- [ ] `ReadFromPipeAsync` catch block includes `return` after `Tell(ReadFinished.Instance)`
+- [ ] `DisposeSocket` CTS disposal is safe (no double-cancel race with `CleanUpGracefully`)
+- [ ] All existing E2E tests pass
+- [ ] New test: concurrent disconnect + publish does not deadlock or crash
+- [ ] New test: rapid sequential reconnects (3+ in < 1 second) complete without error
+- [ ] New test: server kills connection during QoS 2 exchange — client reconnects and retransmits
+- [ ] New test: disconnect while large publish in flight — verifies graceful drain
+- [ ] Builds with zero warnings
+
+### Task 2.5-C: Add TLS support via TlsStreamProvider
+
+**PRD:** [docs/prd/transport-redesign/README.md](docs/prd/transport-redesign/README.md) §7
+**Surface area:** cross-cutting
+**Verification:** L2
+**Depends on:** Task 2.5-A
+
+Implement TLS/SSL support. This is the payoff of the `IStreamProvider` abstraction.
+
+Done when:
+- [ ] `TlsStreamProvider` exists in `src/TurboMqtt/IO/Tcp/TlsStreamProvider.cs`
+- [ ] `TlsStreamProvider.ConnectAsync()` creates Socket → `NetworkStream` → `SslStream`, completes TLS handshake
+- [ ] `MqttClientTlsOptions` public options class exists in `src/TurboMqtt/Client/MqttClientTlsOptions.cs`
+- [ ] `MqttClientTlsOptions` supports: `ClientCertificates`, `ServerCertificateValidationCallback`, `EnabledSslProtocols`, `TargetHost`
+- [ ] `IMqttClientFactory.CreateTlsTcpClient()` factory method added
+- [ ] `TcpMqttTransportManager` accepts optional TLS options and creates appropriate `IStreamProvider`
+- [ ] Container test: connect to EMQX over TLS (port 8883) and publish/subscribe at QoS 0
+- [ ] Container test: connect to EMQX over TLS and publish/subscribe at QoS 1
+- [ ] Container test: TLS with custom `ServerCertificateValidationCallback` for self-signed certs
+- [ ] All existing TCP tests still pass (no regression)
+- [ ] `PROJECT_CONTEXT.md` protocol support table updated: TLS status changed from "In-flight" to "Implemented"
+- [ ] Builds with zero warnings
+
+### Task 2.5-D: Transport lifecycle hardening
+
+**PRD:** [docs/prd/transport-redesign/README.md](docs/prd/transport-redesign/README.md) §5, §6
+**Surface area:** cross-cutting
+**Verification:** L2
+**Depends on:** Tasks 2.5-A + 2.5-B
+
+Formalize the transport state machine and graceful drain to production quality.
+
+Done when:
+- [ ] Full FSM with explicit state transitions and structured logging at each transition
+- [ ] `ConnectionState` shared mutable state replaced with actor messages or thread-safe wrappers
+- [ ] Graceful drain: `Draining` state where outbound flushes before DISCONNECT is sent
+- [ ] Connect timeout with cancellation propagation (configurable, default 10s)
+- [ ] Actor test: verify all state transitions with TestProbe (`NotStarted → Created → Connecting → Connected → Draining → Closing → Stopped`)
+- [ ] Actor test: verify `Aborted` short-circuit path
+- [ ] Test: disconnect while large publish in flight — outbound flushes before close
+- [ ] Test: connect timeout fires when broker is unreachable
+- [ ] All E2E tests pass
+- [ ] Builds with zero warnings
+
+---
+
 ## Phase 3: MQTT 5.0 Implementation
 
 > Goal: Implement a functional MQTT 5.0 encoder and decoder, integrate them into
@@ -294,7 +397,8 @@ Done when:
 > **PRD:** [docs/prd/mqtt5/README.md](docs/prd/mqtt5/README.md) — detailed spec-to-code mapping
 >
 > **Prerequisites:** Phase 2 tasks 2.1-2.5 should be complete so the property-based
-> testing infrastructure can be reused for MQTT 5.0 codec validation.
+> testing infrastructure can be reused for MQTT 5.0 codec validation. Phase 2.5
+> (Transport Layer Redesign) should be complete so MQTT 5.0 builds on a solid transport.
 
 ### Task 3.0: Build MQTT 5.0 property encoding/decoding infrastructure
 
@@ -532,8 +636,8 @@ Done when:
 **Surface area:** cross-cutting
 **Verification:** L3
 
-Add TCP+TLS benchmarks for MQTT 5.0, building on the TLS support from Phase 2
-(Task 2.7) and MQTT 5.0 benchmarks from Task 3.11.
+Add TCP+TLS benchmarks for MQTT 5.0, building on the TLS support from Phase 2.5
+(Task 2.5-C) and MQTT 5.0 benchmarks from Task 3.11.
 
 Done when:
 - [ ] `Mqtt5TlsTcpBenchmarks.cs` exists in `benchmarks/TurboMqtt.Benchmarks/Mqtt5/`
@@ -558,10 +662,15 @@ Phase 2 (depends on Phase 1 completing):
   2.4 (independent, can run in parallel with 2.1-2.3)
   2.5 (independent, can run in parallel)
   2.6 (independent, can run in parallel)
-  2.7 (independent, can run in parallel)
-  2.8 (depends on 2.7 for TLS fixture if auth tests include TLS)
+  2.7 (superseded by Phase 2.5-C)
+  2.8 (independent, can run in parallel)
 
-Phase 3 (depends on Phase 2 tasks 2.1-2.5 for testing infrastructure):
+Phase 2.5 (depends on Phase 2 tasks 2.1-2.6 completing):
+  2.5-A (Stream abstraction) <--> 2.5-B (race fixes)  [can run in parallel]
+  2.5-A --> 2.5-C (TLS depends on IStreamProvider)
+  2.5-A + 2.5-B --> 2.5-D (hardening depends on both)
+
+Phase 3 (depends on Phase 2 tasks 2.1-2.5 for testing infrastructure + Phase 2.5):
   3.0 (property infrastructure, first task)
   3.1 (packet field additions, can parallel with 3.0)
   3.0 + 3.1 --> 3.2 (encoder uses property writer + needs complete packet types)
@@ -574,5 +683,5 @@ Phase 3 (depends on Phase 2 tasks 2.1-2.5 for testing infrastructure):
   3.5 --> 3.9 (E2E tests need pipeline)
   3.7 --> 3.10 (auth E2E needs auth flow)
   3.9 --> 3.11 (benchmarks need working E2E)
-  3.11 + 2.7 --> 3.12 (TLS benchmarks need both TLS and MQTT 5.0 benchmarks)
+  3.11 + 2.5-C --> 3.12 (TLS benchmarks need both TLS and MQTT 5.0 benchmarks)
 ```

--- a/IMPLEMENTATION_PLAN_PHASE2_5.md
+++ b/IMPLEMENTATION_PLAN_PHASE2_5.md
@@ -1,0 +1,127 @@
+# Implementation Plan — Phase 2.5: Transport Layer Redesign
+
+> Scoped plan file for RALPH runs targeting Phase 2.5 only.
+> Full plan: [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md)
+> PRD: [docs/prd/transport-redesign/README.md](docs/prd/transport-redesign/README.md)
+>
+> **Format:** Tasks use `### Task X.Y:` headers with `Done when:` checklists.
+> RALPH picks the FIRST incomplete task (has unchecked `- [ ]` items).
+
+---
+
+## Phase 2.5: Transport Layer Redesign
+
+> Goal: Fix 12+ race conditions in the transport/lifecycle layer, eliminate GC pressure
+> from unpooled read allocations, introduce a `Stream` abstraction to enable TLS, and
+> formalize the transport actor state machine. This must happen before MQTT 5.0 because
+> the transport layer needs to be solid before adding protocol complexity.
+>
+> **PRD:** [docs/prd/transport-redesign/README.md](docs/prd/transport-redesign/README.md)
+
+### Task 2.5-A: Extract Stream abstraction and pool read allocations
+
+**PRD:** [docs/prd/transport-redesign/README.md](docs/prd/transport-redesign/README.md) §4, §8
+**Surface area:** cross-cutting
+**Verification:** L2
+
+Introduce `IStreamProvider` + `TcpStreamProvider`, refactor `TcpTransportActor` to use
+`Stream.ReadAsync`/`Stream.WriteAsync` instead of `Socket.ReceiveAsync`/`Socket.SendAsync`,
+and replace `new byte[]` allocations in `ReadFromPipeAsync` with `MemoryPool<byte>.Shared.Rent()`.
+
+Done when:
+- [ ] `IStreamProvider` interface exists in `src/TurboMqtt/IO/Tcp/IStreamProvider.cs`
+- [ ] `TcpStreamProvider` implementation exists in `src/TurboMqtt/IO/Tcp/TcpStreamProvider.cs`
+- [ ] `TcpStreamProvider.ConnectAsync()` creates Socket, resolves DNS, connects, returns `NetworkStream`
+- [ ] `TcpTransportActor` constructor takes `IStreamProvider` instead of creating Socket directly
+- [ ] `DoWriteToPipeAsync` reads from `Stream.ReadAsync()` instead of `Socket.ReceiveAsync()`
+- [ ] `DoWriteToSocketAsync` writes to `Stream.WriteAsync()` instead of `Socket.SendAsync()`
+- [ ] `ReadFromPipeAsync` uses `MemoryPool<byte>.Shared.Rent()` instead of `new byte[buffer.Length]`
+- [ ] `UnsharedMemoryOwner` no longer used on the read path (may still be used elsewhere)
+- [ ] `TcpTransport.cs` updated to pass `IStreamProvider` through
+- [ ] `TcpConnectionManager.cs` updated to create appropriate `IStreamProvider`
+- [ ] All existing TCP unit tests pass unchanged
+- [ ] All container tests pass against EMQX
+- [ ] New unit tests for `TcpStreamProvider` (connect, DNS resolution, socket configuration)
+- [ ] BenchmarkDotNet before/after confirms no throughput regression (baseline: 193k msg/sec QoS 0)
+- [ ] Builds with zero warnings
+
+### Task 2.5-B: Fix transport race conditions
+
+**PRD:** [docs/prd/transport-redesign/README.md](docs/prd/transport-redesign/README.md) §1.2, §5, §6
+**Surface area:** cross-cutting
+**Verification:** L2
+
+Fix the 12+ identified race conditions in shutdown, reconnection, and transport swap.
+Can be developed in parallel with Task 2.5-A.
+
+Done when:
+- [ ] `TcpTransportActor` uses explicit `Become` states: `NotStarted → Created → Connecting → Connected → Draining → Closing → Stopped` (and `Aborted` short-circuit)
+- [ ] Background tasks in `BecomeRunning()` tracked with `Task.WhenAll` + `ContinueWith` self-tell `BackgroundTasksCompleted`
+- [ ] `CleanUpGracefully` replaced with state-driven transitions — no more fire-and-forget async
+- [ ] Duplicate `DoClose`/`ReadFinished`/`ConnectionUnexpectedlyClosed` messages in non-handling states are ignored
+- [ ] `MqttClient.SwapTransport()` uses `Interlocked.Exchange` + `volatile` field
+- [ ] TOCTOU on `IsConnected` in `PublishAsync` eliminated — rely on `TryWrite` returning false
+- [ ] `ClientStreamOwner.PostStop()` follows deterministic ordering: complete outbound → abort transport → complete inbound → signal death
+- [ ] `ClientStreamOwner` reconnect uses message-driven `Reconnecting` behavior (no fire-and-forget `DoReconnect`)
+- [ ] `ReadFromPipeAsync` catch block includes `return` after `Tell(ReadFinished.Instance)`
+- [ ] `DisposeSocket` CTS disposal is safe (no double-cancel race with `CleanUpGracefully`)
+- [ ] All existing E2E tests pass
+- [ ] New test: concurrent disconnect + publish does not deadlock or crash
+- [ ] New test: rapid sequential reconnects (3+ in < 1 second) complete without error
+- [ ] New test: server kills connection during QoS 2 exchange — client reconnects and retransmits
+- [ ] New test: disconnect while large publish in flight — verifies graceful drain
+- [ ] Builds with zero warnings
+
+### Task 2.5-C: Add TLS support via TlsStreamProvider
+
+**PRD:** [docs/prd/transport-redesign/README.md](docs/prd/transport-redesign/README.md) §7
+**Surface area:** cross-cutting
+**Verification:** L2
+**Depends on:** Task 2.5-A
+
+Implement TLS/SSL support. This is the payoff of the `IStreamProvider` abstraction.
+
+Done when:
+- [ ] `TlsStreamProvider` exists in `src/TurboMqtt/IO/Tcp/TlsStreamProvider.cs`
+- [ ] `TlsStreamProvider.ConnectAsync()` creates Socket → `NetworkStream` → `SslStream`, completes TLS handshake
+- [ ] `MqttClientTlsOptions` public options class exists in `src/TurboMqtt/Client/MqttClientTlsOptions.cs`
+- [ ] `MqttClientTlsOptions` supports: `ClientCertificates`, `ServerCertificateValidationCallback`, `EnabledSslProtocols`, `TargetHost`
+- [ ] `IMqttClientFactory.CreateTlsTcpClient()` factory method added
+- [ ] `TcpMqttTransportManager` accepts optional TLS options and creates appropriate `IStreamProvider`
+- [ ] Container test: connect to EMQX over TLS (port 8883) and publish/subscribe at QoS 0
+- [ ] Container test: connect to EMQX over TLS and publish/subscribe at QoS 1
+- [ ] Container test: TLS with custom `ServerCertificateValidationCallback` for self-signed certs
+- [ ] All existing TCP tests still pass (no regression)
+- [ ] `PROJECT_CONTEXT.md` protocol support table updated: TLS status changed from "In-flight" to "Implemented"
+- [ ] Builds with zero warnings
+
+### Task 2.5-D: Transport lifecycle hardening
+
+**PRD:** [docs/prd/transport-redesign/README.md](docs/prd/transport-redesign/README.md) §5, §6
+**Surface area:** cross-cutting
+**Verification:** L2
+**Depends on:** Tasks 2.5-A + 2.5-B
+
+Formalize the transport state machine and graceful drain to production quality.
+
+Done when:
+- [ ] Full FSM with explicit state transitions and structured logging at each transition
+- [ ] `ConnectionState` shared mutable state replaced with actor messages or thread-safe wrappers
+- [ ] Graceful drain: `Draining` state where outbound flushes before DISCONNECT is sent
+- [ ] Connect timeout with cancellation propagation (configurable, default 10s)
+- [ ] Actor test: verify all state transitions with TestProbe (`NotStarted → Created → Connecting → Connected → Draining → Closing → Stopped`)
+- [ ] Actor test: verify `Aborted` short-circuit path
+- [ ] Test: disconnect while large publish in flight — outbound flushes before close
+- [ ] Test: connect timeout fires when broker is unreachable
+- [ ] All E2E tests pass
+- [ ] Builds with zero warnings
+
+---
+
+## Dependency Graph
+
+```
+2.5-A (Stream abstraction) <--> 2.5-B (race fixes)  [can run in parallel]
+2.5-A --> 2.5-C (TLS depends on IStreamProvider)
+2.5-A + 2.5-B --> 2.5-D (hardening depends on both)
+```

--- a/docs/prd/transport-redesign/README.md
+++ b/docs/prd/transport-redesign/README.md
@@ -1,0 +1,392 @@
+# PRD: Transport Layer Redesign
+
+**Status:** Draft
+**Date:** 2026-02-19
+**Phase:** 2.5 (between MQTT 3.1.1 Hardening and MQTT 5.0 Implementation)
+
+---
+
+## 1. Problem Statement
+
+TurboMqtt's TCP transport layer (`TcpTransportActor`, `TcpTransport`, `ClientStreamOwner`) has accumulated 12+ race conditions, blocks TLS support, and performs unnecessary heap allocations on every inbound read. These issues must be resolved before adding MQTT 5.0 protocol complexity.
+
+### 1.1 Current Architecture
+
+```
+Socket.ReceiveAsync → Pipe.Writer → Pipe.Reader → new byte[] COPY → Channel → Akka.Streams
+                                                                         ↑
+Socket.SendAsync ← Channel ← Akka.Streams                              |
+                                                                   UnsharedMemoryOwner
+                                                                   (no-op Dispose)
+```
+
+**Key components:**
+
+| Component | File | Responsibility |
+|-----------|------|----------------|
+| `TcpTransportActor` | `src/TurboMqtt/IO/Tcp/TcpTransportActor.cs` | Owns Socket, Pipe, Channels; runs 3 background tasks |
+| `TcpTransport` | `src/TurboMqtt/IO/Tcp/TcpTransport.cs` | `IMqttTransport` facade over actor state |
+| `TcpConnectionManager` | `src/TurboMqtt/IO/Tcp/TcpConnectionManager.cs` | Actor that creates `TcpTransportActor` children |
+| `ClientStreamOwner` | `src/TurboMqtt/Client/ClientStreamOwner.cs` | Owns client lifecycle, reconnection, stream creation |
+| `ClientStreamInstance` | `src/TurboMqtt/Client/ClientStreamInstance.cs` | Creates Akka.Streams graphs for encode/decode |
+| `MqttClient` | `src/TurboMqtt/Client/IMqttClient.cs` | Public API, holds `IMqttTransport` reference |
+
+### 1.2 Catalogued Race Conditions
+
+| # | Location | Description | Severity |
+|---|----------|-------------|----------|
+| 1 | `TcpTransportActor.BecomeRunning()` | Three background tasks (`DoWriteToPipeAsync`, `ReadFromPipeAsync`, `DoWriteToSocketAsync`) launched with `#pragma warning disable CS4014` — fire-and-forget with no tracking, no `Task.WhenAll`, no completion self-tell | High |
+| 2 | `TcpTransportActor.CleanUpGracefully()` | Uses `_ = CleanUpGracefully(true)` — fire-and-forget async from actor message handler. The `Task.Delay(100)` is a timing hack that may not be sufficient | High |
+| 3 | `TcpTransportActor.CleanUpGracefully()` | Sends `PoisonPill.Instance` to self at end, but `CleanUpGracefully` can be invoked multiple times from `DoClose`, `ReadFinished`, and `ConnectionUnexpectedlyClosed` messages — no idempotency guard | High |
+| 4 | `TcpTransportActor.Running()` | All three message types (`DoClose`, `ReadFinished`, `ConnectionUnexpectedlyClosed`) fire-and-forget `CleanUpGracefully(true)` — concurrent invocations race against each other | High |
+| 5 | `ClientStreamOwner.PostStop()` | Calls `_currentTransport?.AbortAsync()` as fire-and-forget — no await, no tracking | Medium |
+| 6 | `ClientStreamOwner.Running()` `ServerDisconnect` | Calls `_ = _currentTransport?.AbortAsync()` fire-and-forget, then `Context.Stop(_streamInstanceOwner)` — stop may execute before abort completes | Medium |
+| 7 | `ClientStreamOwner.Running()` `TransportFailedToConnect` | Same fire-and-forget `_ = _currentTransport?.AbortAsync()` pattern | Medium |
+| 8 | `ClientStreamOwner.Running()` `StreamTerminated` | `DoReconnect` is fire-and-forget (`_ = DoReconnect(...)`) inside a `RunTask` — the RunTask itself is awaited, but `DoReconnect` inside it is not | High |
+| 9 | `MqttClient.SwapTransport()` | Plain field assignment `_transport = newTransport` — not thread-safe if `PublishAsync` or `IsConnected` reads `_transport` concurrently | Medium |
+| 10 | `MqttClient.PublishAsync()` / `IsConnected` | TOCTOU: checks `_transport.Status != ConnectionStatus.Connected` then proceeds to write — status can change between check and write | Low |
+| 11 | `ClientStreamInstance.NotifyOnDisconnect()` | Fire-and-forget `async Task` — if `disconnectPromise.Task` never completes, this task leaks | Low |
+| 12 | `TcpTransportActor.ReadFromPipeAsync()` | `catch (OperationCanceledException)` does not `return` — after `_closureSelf.Tell(ReadFinished.Instance)`, execution falls through to next loop iteration and may `ReadAsync` again on a cancelled token | Medium |
+| 13 | `TcpTransportActor.DisposeSocket()` / `PostStop()` | `ShutDownCts.Cancel()` is called synchronously (not `CancelAsync()`) — may throw if CTS is already disposed. Called from `FullShutdown` which is called from `PostStop`, racing with `CleanUpGracefully` which calls `CancelAsync()` | Medium |
+
+### 1.3 GC Pressure from Unpooled Allocations
+
+In `TcpTransportActor.ReadFromPipeAsync()` (line 445):
+
+```csharp
+var newMemory = new Memory<byte>(new byte[buffer.Length]);
+var unshared = new UnsharedMemoryOwner<byte>(newMemory);
+buffer.CopyTo(newMemory.Span);
+```
+
+Every inbound read allocates a fresh `byte[]` on the heap and wraps it in an `UnsharedMemoryOwner<T>` whose `Dispose()` is a no-op. This means:
+- **Full buffer copy** on every read (Pipe → heap array)
+- **No pooling** — allocations hit GC (Gen 0 pressure at 193k msg/sec)
+- **No real disposal** — `UnsharedMemoryOwner.Dispose()` does nothing, so memory lifetime is tied to GC rather than deterministic cleanup
+
+The fix: use `MemoryPool<byte>.Shared.Rent()` to produce a real `IMemoryOwner<byte>` that returns to the pool on `Dispose()`.
+
+### 1.4 No TLS Support Path
+
+`TcpTransportActor` creates a raw `Socket` and calls `Socket.ReceiveAsync()` / `Socket.SendAsync()` directly. There is no `Stream` abstraction layer where `SslStream` could be inserted. TLS requires:
+
+1. `Socket` → `NetworkStream` → `SslStream` wrapping
+2. Reading/writing via `Stream.ReadAsync()` / `Stream.WriteAsync()` instead of `Socket` directly
+3. TLS handshake must complete before data flows to the Pipe
+
+The `IStreamProvider` abstraction (Phase 2.5-A) solves this by inserting a `Stream` layer between the Socket and the Pipe.
+
+---
+
+## 2. Rejected Alternatives
+
+### 2.1 Akka.Streams.Dsl.Tcp
+
+`Akka.Streams.Dsl.Tcp.OutgoingConnection()` returns `Flow<ByteString, ByteString, ...>`. This was considered and rejected because:
+
+- **ByteString is immutable and copies on concat** — fundamentally incompatible with TurboMqtt's pooled `IMemoryOwner<byte>` / `Span<T>` memory model
+- The entire encoder/decoder pipeline is built around `MemoryPool<byte>.Rent()` + `Span` slicing
+- Switching to ByteString would force copies at both TCP and decoder layers
+- Would break `BatchWeighted` frame packing optimization (which works on `Memory<byte>` slices)
+- Estimated **15-30% throughput regression** from double-copying
+- Adding `SslStream` as a `BidiFlow` on top adds yet another buffer layer
+- Adapter stages between `ByteString` and `Memory<byte>` would negate any simplification
+
+### 2.2 PR #182: Direct IDuplexPipe to Akka.Streams
+
+PR #182 attempted to replace the `Channel` intermediary with `IDuplexPipe` connected directly to Akka.Streams `GraphStage`s. After 50+ commits, it was abandoned because:
+
+- **Pipes expect external completion signaling** — the consumer calls `PipeReader.Complete()` / `PipeWriter.Complete()` to signal lifecycle
+- **Akka.Streams expects completion to flow through graph topology** — a `Source` completes, and completion propagates downstream through the graph
+- These two lifecycle models are fundamentally incompatible
+- `PipeReader.ReadAsync()` inside a `GraphStage.OnPull()` requires `async` in a context that doesn't naturally support it
+- Backpressure mapping between Pipe's `PauseWriterThreshold` and Akka.Streams demand signals is non-trivial
+- Completion signaling required complex coordination that was fragile and non-deterministic
+
+### 2.3 Why Channels Work
+
+`System.Threading.Channels` has a simple completion model:
+- `Writer.TryComplete()` signals no more data
+- `Reader.Completion` is a `Task` that completes when the writer is done
+- `TryWrite()` / `TryRead()` are non-blocking and return `bool`
+
+This maps cleanly to both Akka.Streams (via `ChannelSource`/`ChannelSink`) and the transport actor (direct `TryWrite`/`TryRead` in background tasks). The Channel stays as the boundary.
+
+---
+
+## 3. Recommended Approach: Hybrid (Option C)
+
+Keep `Channel<(IMemoryOwner<byte>, int)>` as the boundary between transport and Akka.Streams. Fix everything **below** that boundary.
+
+```
+Current:  Socket → Pipe → FULL COPY (new byte[]) → Channel → Akka.Streams
+Proposed: Stream → Pipe → pooled copy (Rent())   → Channel → Akka.Streams
+             ^
+             +-- NetworkStream (plain TCP)
+             +-- SslStream(NetworkStream) (TLS)
+             +-- custom Stream (QUIC future)
+```
+
+**Key architectural insight:** TLS belongs at the `Stream` level, not at the Channel or Akka.Streams level. By abstracting `Stream` creation behind `IStreamProvider`, we can support TCP, TLS, and future transports (QUIC) without changing the Channel boundary or Akka.Streams graphs.
+
+---
+
+## 4. IStreamProvider Abstraction
+
+### 4.1 Interface Design
+
+```csharp
+/// <summary>
+/// Abstracts the creation of a connected Stream for the transport layer.
+/// Implementations handle protocol-specific setup (TCP, TLS, QUIC).
+/// </summary>
+internal interface IStreamProvider : IAsyncDisposable
+{
+    /// <summary>
+    /// Creates and connects the underlying transport, returning a Stream
+    /// suitable for reading and writing MQTT frames.
+    /// </summary>
+    /// <param name="ct">Cancellation token for the connect operation.</param>
+    /// <returns>A connected, ready-to-use Stream.</returns>
+    Task<Stream> ConnectAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// The underlying Socket (for buffer size configuration, linger, etc.)
+    /// May be null for non-socket transports.
+    /// </summary>
+    Socket? UnderlyingSocket { get; }
+}
+```
+
+### 4.2 Implementations
+
+**`TcpStreamProvider`** — Plain TCP:
+1. Creates `Socket` with configured `AddressFamily`, `NoDelay`, `LingerState`, buffer sizes
+2. Resolves DNS, calls `Socket.ConnectAsync()`
+3. Returns `new NetworkStream(socket, ownsSocket: true)`
+
+**`TlsStreamProvider`** — TLS over TCP (Phase 2.5-C):
+1. Delegates to `TcpStreamProvider` for socket creation and connection
+2. Wraps returned `NetworkStream` with `SslStream`
+3. Calls `SslStream.AuthenticateAsClientAsync()` with configured certificates and validation
+4. Returns the `SslStream`
+
+### 4.3 How It Integrates
+
+`TcpTransportActor` constructor takes an `IStreamProvider` instead of creating a `Socket` directly:
+
+```
+TcpTransportActor(IStreamProvider streamProvider, int maxFrameSize)
+```
+
+The actor calls `streamProvider.ConnectAsync()` during the `DoConnect` handler, receives a `Stream`, and uses `Stream.ReadAsync()` / `Stream.WriteAsync()` in its background tasks instead of `Socket.ReceiveAsync()` / `Socket.SendAsync()`.
+
+---
+
+## 5. Transport Actor FSM Design
+
+### 5.1 State Machine
+
+Replace the ad-hoc state management (mix of `ConnectionStatus` enum, `Become()` calls, and `CleanUpGracefully()`) with an explicit FSM:
+
+```
+NotStarted ──CreateTcpTransport──> Created
+Created ──DoConnect──> Connecting
+Connecting ──ConnectResult(ok)──> Connected
+Connecting ──ConnectResult(fail)──> Stopped
+Connected ──DoClose──> Draining
+Connected ──ReadFinished──> Closing
+Connected ──ConnectionUnexpectedlyClosed──> Aborted
+Draining ──OutboundFlushed──> Closing
+Draining ──timeout──> Closing
+Closing ──BackgroundTasksCompleted──> Stopped
+Aborted ──BackgroundTasksCompleted──> Stopped
+```
+
+### 5.2 Key State Behaviors
+
+**Connected:**
+- Three background tasks running (`DoWriteToPipeAsync`, `ReadFromPipeAsync`, `DoWriteToSocketAsync`)
+- All three tracked via `Task.WhenAll` with `ContinueWith` self-tell `BackgroundTasksCompleted`
+
+**Draining:**
+- Outbound channel writer completed — no new writes accepted
+- Wait for outbound stream to flush pending data
+- After flush (or timeout), transition to `Closing`
+
+**Closing:**
+- Cancel the `ShutDownCts` to stop background tasks
+- Wait for `BackgroundTasksCompleted` self-tell
+- Dispose stream provider, complete channels
+- Send `PoisonPill` to self (exactly once)
+
+**Aborted:**
+- Immediate cancel of `ShutDownCts`
+- No drain wait
+- Same `BackgroundTasksCompleted` → `Stopped` path
+
+### 5.3 Idempotency
+
+Each state only accepts its valid messages. Duplicate `DoClose`, `ReadFinished`, or `ConnectionUnexpectedlyClosed` messages in states that don't handle them are simply ignored (or logged at debug level). This eliminates races #3 and #4 from the catalogue.
+
+---
+
+## 6. Lifecycle Coordination
+
+### 6.1 Background Task Tracking
+
+Replace fire-and-forget with tracked tasks:
+
+```csharp
+private void BecomeConnected()
+{
+    Become(Connected);
+
+    var readTask = DoWriteToPipeAsync(State.ShutDownCts.Token);
+    var pipeTask = ReadFromPipeAsync(State.ShutDownCts.Token);
+    var writeTask = DoWriteToSocketAsync(State.ShutDownCts.Token);
+
+    Task.WhenAll(readTask, pipeTask, writeTask).ContinueWith(_ =>
+    {
+        _closureSelf.Tell(BackgroundTasksCompleted.Instance);
+    });
+}
+```
+
+### 6.2 PostStop Ordering
+
+`ClientStreamOwner.PostStop()` must follow a deterministic sequence:
+
+1. Complete outbound channel writer (stops new data entering stream)
+2. Abort transport (cancels background tasks, disposes stream)
+3. Complete inbound channel writer (terminates consumer)
+4. Signal `_trueDeath` TCS (unblocks `WhenTerminated`)
+5. Tell parent `ClientDied`
+
+### 6.3 Reconnect State Machine
+
+Replace fire-and-forget `DoReconnect` with message-driven reconnection in `ClientStreamOwner`:
+
+1. `StreamTerminated` received → enter `Reconnecting` behavior via `Become(Reconnecting)`
+2. `Reconnecting` state uses `RunTask` to await transport creation + `ConnectAsync`
+3. On success, self-tell `ReconnectSuccess` → `Become(Running)`
+4. On failure, self-tell `ReconnectFailed` → decrement retries, either retry or shutdown
+
+This eliminates the nested fire-and-forget async inside `RunTask` (race #8).
+
+---
+
+## 7. TLS Integration Approach
+
+### 7.1 Configuration
+
+```csharp
+public sealed record MqttClientTlsOptions
+{
+    /// <summary>
+    /// Enable TLS for the connection.
+    /// </summary>
+    public bool UseTls { get; init; }
+
+    /// <summary>
+    /// Client certificates for mutual TLS authentication.
+    /// </summary>
+    public X509CertificateCollection? ClientCertificates { get; init; }
+
+    /// <summary>
+    /// Custom server certificate validation callback.
+    /// When null, uses default system validation.
+    /// </summary>
+    public RemoteCertificateValidationCallback? ServerCertificateValidationCallback { get; init; }
+
+    /// <summary>
+    /// The TLS/SSL protocols to use. Defaults to system default (TLS 1.2+).
+    /// </summary>
+    public SslProtocols EnabledSslProtocols { get; init; } = SslProtocols.None; // system default
+
+    /// <summary>
+    /// Target host name for TLS SNI. Defaults to MqttClientTcpOptions.Host.
+    /// </summary>
+    public string? TargetHost { get; init; }
+}
+```
+
+### 7.2 Factory Method
+
+```csharp
+public interface IMqttClientFactory
+{
+    Task<IMqttClient> CreateTcpClient(MqttClientConnectOptions options, MqttClientTcpOptions tcpOptions);
+
+    // New: TLS variant
+    Task<IMqttClient> CreateTlsTcpClient(
+        MqttClientConnectOptions options,
+        MqttClientTcpOptions tcpOptions,
+        MqttClientTlsOptions tlsOptions);
+}
+```
+
+### 7.3 Stream Layer
+
+TLS wrapping happens entirely inside `TlsStreamProvider`:
+
+```
+Socket → NetworkStream → SslStream.AuthenticateAsClientAsync() → return SslStream
+```
+
+No changes needed to `TcpTransportActor`, Channels, or Akka.Streams graphs. The actor reads and writes a `Stream` — it does not know or care whether that Stream is a `NetworkStream` or `SslStream`.
+
+---
+
+## 8. Pooled Memory on Read Path
+
+### 8.1 Current (wasteful)
+
+```csharp
+// TcpTransportActor.ReadFromPipeAsync() — current code
+var newMemory = new Memory<byte>(new byte[buffer.Length]);
+var unshared = new UnsharedMemoryOwner<byte>(newMemory);
+buffer.CopyTo(newMemory.Span);
+_readsFromTransport.Writer.TryWrite((unshared, newMemory.Length));
+```
+
+### 8.2 Proposed (pooled)
+
+```csharp
+// TcpTransportActor.ReadFromPipeAsync() — proposed
+var owner = MemoryPool<byte>.Shared.Rent((int)buffer.Length);
+buffer.CopyTo(owner.Memory.Span);
+_readsFromTransport.Writer.TryWrite((owner, (int)buffer.Length));
+```
+
+The copy is still necessary (Pipe buffers are reused after `AdvanceTo`), but the allocation is pooled. Downstream consumers already call `IMemoryOwner<byte>.Dispose()` which now returns the buffer to the pool instead of being a no-op.
+
+---
+
+## 9. Implementation Phases
+
+See `IMPLEMENTATION_PLAN.md` Phase 2.5 for detailed task breakdown. Summary:
+
+| Phase | Goal | Dependencies | Risk |
+|-------|------|--------------|------|
+| 2.5-A | Extract `IStreamProvider`, pool read allocations | None | Medium |
+| 2.5-B | Fix 12+ race conditions with FSM + task tracking | None | Low |
+| 2.5-C | Add TLS via `TlsStreamProvider` | 2.5-A | Low |
+| 2.5-D | Formalize FSM, graceful drain, connect timeout | 2.5-A + 2.5-B | Medium |
+
+```
+2.5-A (Stream Abstraction)  <-->  2.5-B (Race Fixes)  [parallel]
+         |                              |
+    2.5-C (TLS)                    2.5-D (Hardening)  [after both A+B]
+```
+
+---
+
+## 10. Success Criteria
+
+- All existing TCP E2E tests pass unchanged after each phase
+- Container tests pass against EMQX after each phase
+- BenchmarkDotNet before/after confirms no throughput regression (baseline: 193k msg/sec QoS 0)
+- New TLS container tests pass against EMQX with TLS enabled
+- Zero new compiler warnings
+- Race condition catalogue items verified fixed via targeted tests

--- a/ralph-opencode.sh
+++ b/ralph-opencode.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 # doesn't fire and the loop continues to the next iteration.
 trap 'echo ""; echo "RALPH loop interrupted."; exit 130' INT TERM
 
-PLAN_FILE="IMPLEMENTATION_PLAN.md"
+PLAN_FILE="${RALPH_PLAN_FILE:-IMPLEMENTATION_PLAN.md}"
 ITERATIONS=5
 MODEL="${RALPH_MODEL:-github-copilot/claude-opus-4.5}"
 POSTMORTEM_MODEL="${RALPH_POSTMORTEM_MODEL:-$MODEL}"
@@ -328,11 +328,11 @@ for ((i=1; i<=ITERATIONS; i++)); do
 1. AGENTS.md and/or CLAUDE.md - Constitution (authority, constraints, quality bar, routing)
 2. PROJECT_CONTEXT.md - Current architecture and state (if present)
 3. TOOLING.md - Available tools/services (if present)
-4. IMPLEMENTATION_PLAN.md - Task breakdown
+4. $PLAN_FILE - Task breakdown
 
 ## Instructions (ONE TASK ONLY)
 
-1) Find the next incomplete task in IMPLEMENTATION_PLAN.md:
+1) Find the next incomplete task in $PLAN_FILE:
    - Look for '### Task:' blocks with unchecked 'Done when:' items
    - Work on the FIRST incomplete task you find
    - A task is complete only when ALL its Done-when checkboxes are satisfied
@@ -371,7 +371,7 @@ for ((i=1; i<=ITERATIONS; i++)); do
 
 8) If verification passes:
    - Commit to the current feature branch with a descriptive message
-   - Update IMPLEMENTATION_PLAN.md checkboxes in the SAME commit
+   - Update $PLAN_FILE checkboxes in the SAME commit
    - Update TOOLING.md if you used or discovered a new tool/resource
 
 9) Stop at checkpoints (UI approval, architecture decisions, credential setup) and ask the user if needed.

--- a/ralph.sh
+++ b/ralph.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 # doesn't fire and the loop continues to the next iteration.
 trap 'echo ""; echo "RALPH loop interrupted."; exit 130' INT TERM
 
-PLAN_FILE="IMPLEMENTATION_PLAN.md"
+PLAN_FILE="${RALPH_PLAN_FILE:-IMPLEMENTATION_PLAN.md}"
 ITERATIONS=5
 MODEL="${RALPH_MODEL:-claude-opus-4-6}"
 POSTMORTEM_MODEL="${RALPH_POSTMORTEM_MODEL:-$MODEL}"
@@ -332,11 +332,11 @@ for ((i=1; i<=ITERATIONS; i++)); do
 1. AGENTS.md and/or CLAUDE.md - Constitution (authority, constraints, quality bar, routing)
 2. PROJECT_CONTEXT.md - Current architecture and state (if present)
 3. TOOLING.md - Available tools/services (if present)
-4. IMPLEMENTATION_PLAN.md - Task breakdown
+4. $PLAN_FILE - Task breakdown
 
 ## Instructions (ONE TASK ONLY)
 
-1) Find the next incomplete task in IMPLEMENTATION_PLAN.md:
+1) Find the next incomplete task in $PLAN_FILE:
    - Look for '### Task:' blocks with unchecked 'Done when:' items
    - Work on the FIRST incomplete task you find
    - A task is complete only when ALL its Done-when checkboxes are satisfied
@@ -375,7 +375,7 @@ for ((i=1; i<=ITERATIONS; i++)); do
 
 8) If verification passes:
    - Commit to the current feature branch with a descriptive message
-   - Update IMPLEMENTATION_PLAN.md checkboxes in the SAME commit
+   - Update $PLAN_FILE checkboxes in the SAME commit
    - Update TOOLING.md if you used or discovered a new tool/resource
 
 9) Stop at checkpoints (UI approval, architecture decisions, credential setup) and ask the user if needed.


### PR DESCRIPTION
- New PRD at docs/prd/transport-redesign/README.md cataloguing 13 race conditions, GC pressure from unpooled read allocations, and the lack of a Stream abstraction blocking TLS support
- Documents rejected alternatives (Akka.Streams.Tcp, PR #182 IDuplexPipe) and the recommended hybrid approach keeping Channels as the boundary
- Adds Phase 2.5 (A-D) to IMPLEMENTATION_PLAN.md between Phase 2 and Phase 3: Stream abstraction, race condition fixes, TLS, lifecycle hardening
- Task 2.7 (old TLS placeholder) superseded by Phase 2.5-C
- Phase 3 prerequisites updated to include Phase 2.5
- Dependency graph updated with Phase 2.5 relationships
- RALPH scripts accept RALPH_PLAN_FILE env var for scoped runs
- Standalone IMPLEMENTATION_PLAN_PHASE2_5.md for targeted RALPH execution