### PR TITLE
Phase 2.5: Transport layer redesign with TLS support

### DIFF
--- a/.ralph/runs/20260219-224523/iter-01.md
+++ b/.ralph/runs/20260219-224523/iter-01.md
@@ -1,0 +1,68 @@
+# RALPH Iteration 1 — 2026-02-19
+
+## Task Selected
+**Task 2.5-A: Extract Stream abstraction and pool read allocations**
+
+## Surface Area Classification
+Cross-cutting — transport layer (`IO/Tcp/`), affects actor lifecycle, stream I/O, and memory allocation patterns.
+
+## Verification Level
+**L2** — I/O coordination with actors/external (integration tests required). The transport actor manages TCP sockets, Akka.NET actor lifecycle, and `System.IO.Pipelines`. Changes affect the data path between network I/O and Akka.Streams.
+
+## Skills Consulted
+- `csharp-coding-standards` — modern C# patterns for interface/record design
+- `csharp-type-design-performance` — sealed classes, readonly patterns, MemoryPool usage
+- `akka-testing-patterns` — actor test patterns (existing tests validated unchanged)
+
+## Changes Made
+
+### New Files
+1. **`src/TurboMqtt/IO/Tcp/IStreamProvider.cs`** — `IStreamProvider` interface with `ConnectAsync(host, port, ct)` returning `Stream`, and `Close()` for cleanup.
+2. **`src/TurboMqtt/IO/Tcp/TcpStreamProvider.cs`** — TCP implementation that creates a `Socket`, resolves DNS, connects, and returns `NetworkStream`. Socket configuration (NoDelay, LingerState, buffer sizes) moved here from `TcpTransportActor.CreateTcpClient()`.
+3. **`tests/TurboMqtt.Tests/IO/Tcp/TcpStreamProviderSpecs.cs`** — 9 unit tests covering connect, DNS resolution, cancellation, error cases, socket configuration, explicit address family, and idempotent close.
+
+### Modified Files
+4. **`src/TurboMqtt/IO/Tcp/TcpTransportActor.cs`** — Major refactor:
+   - Constructor now takes `IStreamProvider` instead of creating `Socket` directly
+   - Removed `_tcpClient` (`Socket?`) field, replaced with `_stream` (`Stream?`) and `_streamProvider` (`IStreamProvider`)
+   - Removed `CreateTcpClient()` method — socket creation delegated to `IStreamProvider`
+   - `DoWriteToPipeAsync` now reads from `Stream.ReadAsync()` instead of `Socket.ReceiveAsync()`
+   - `DoWriteToSocketAsync` now writes via `Stream.WriteAsync()` instead of `Socket.SendAsync()`
+   - `ReadFromPipeAsync` now uses `MemoryPool<byte>.Shared.Rent()` instead of `new byte[buffer.Length]` + `UnsharedMemoryOwner`
+   - `DisposeSocket` renamed to `DisposeStreamProvider`, cleans up both `Stream` and `IStreamProvider`
+   - Connect logic simplified: `IStreamProvider.ConnectAsync()` handles DNS + socket creation + connect in one call
+5. **`src/TurboMqtt/IO/Tcp/TcpConnectionManager.cs`** — `CreateTcpTransport` record gains optional `IStreamProvider?` parameter. Default creates `TcpStreamProvider` from options.
+6. **`src/TurboMqtt/IO/Tcp/TcpTransport.cs`** — `TcpMqttTransportManager` gains optional `IStreamProvider?` parameter, passed through to `TcpConnectionManager.CreateTcpTransport`.
+
+## Commands Run + Outcomes
+| Command | Outcome |
+|---------|---------|
+| `dotnet build -c Release` | **Success** — 0 warnings, 0 errors |
+| `dotnet test tests/TurboMqtt.Tests/ -c Release` | **Success** — 222/222 passed |
+| `dotnet test --filter TcpStreamProviderSpecs` | **Success** — 9/9 new tests passed |
+
+## Done-When Checklist Status
+- [x] `IStreamProvider` interface exists in `src/TurboMqtt/IO/Tcp/IStreamProvider.cs`
+- [x] `TcpStreamProvider` implementation exists in `src/TurboMqtt/IO/Tcp/TcpStreamProvider.cs`
+- [x] `TcpStreamProvider.ConnectAsync()` creates Socket, resolves DNS, connects, returns `NetworkStream`
+- [x] `TcpTransportActor` constructor takes `IStreamProvider` instead of creating Socket directly
+- [x] `DoWriteToPipeAsync` reads from `Stream.ReadAsync()` instead of `Socket.ReceiveAsync()`
+- [x] `DoWriteToSocketAsync` writes to `Stream.WriteAsync()` instead of `Socket.SendAsync()`
+- [x] `ReadFromPipeAsync` uses `MemoryPool<byte>.Shared.Rent()` instead of `new byte[buffer.Length]`
+- [x] `UnsharedMemoryOwner` no longer used on the read path (still used in `FakeServerHandle`, `DisconnectToBinary`, `MqttDecodingFlows`)
+- [x] `TcpTransport.cs` updated to pass `IStreamProvider` through
+- [x] `TcpConnectionManager.cs` updated to create appropriate `IStreamProvider`
+- [x] All existing TCP unit tests pass unchanged (222/222)
+- [ ] All container tests pass against EMQX (not run — requires Docker, deferred to CI)
+- [x] New unit tests for `TcpStreamProvider` (9 tests: connect, DNS resolution, socket configuration, cancellation, error cases)
+- [ ] BenchmarkDotNet before/after confirms no throughput regression (deferred — requires EMQX Docker for E2E benchmarks)
+- [x] Builds with zero warnings
+
+## Deviations/Skips + Justification
+1. **Container tests not run locally** — Requires Docker with EMQX. CI pipeline will validate. All non-container TCP E2E tests pass using the FakeMqttTcpServer.
+2. **BenchmarkDotNet not run** — E2E benchmarks require EMQX Docker container (`start-emqx.ps1`). The architectural change (Stream vs Socket) should not regress throughput since `NetworkStream` delegates to the same underlying socket. This should be validated in CI or a dedicated benchmark run.
+3. **`DoWriteToSocketAsync` simplified** — `Stream.WriteAsync` writes all bytes (unlike `Socket.SendAsync` which can do partial sends). Removed the partial-send loop, replacing with a single `WriteAsync` call + setting `readableBytes = 0`. `NetworkStream.WriteAsync` internally handles partial sends.
+
+## Follow-ups Noticed But Deferred
+1. **`MqttDecodingFlows` optimization** — The `is not UnsharedMemoryOwner` check on line 95 now triggers a copy for pooled memory. This is correct (pooled memory must be copied before disposal) but adds an allocation in the hot path. Could be optimized by having the decoder work directly with the pooled memory if packet lifetimes allow. Deferred to Task 2.5-D (hardening).
+2. **`FakeMqttTcpServer` still uses raw Socket** — Not in scope for this task (server-side test infrastructure, not client transport).

--- a/BACKLOG_PARKING_LOT.md
+++ b/BACKLOG_PARKING_LOT.md
@@ -99,3 +99,15 @@
 - **Source:** Adversarial review 20260220-000928, finding G-4
 - **Issue:** Two instances of fire-and-forget `AbortConnectionAsync()` in `ConnectAsync` error paths use pragma suppression. Should properly track the Task or use a discard with a comment.
 - **Date parked:** 2026-02-20
+
+### Annotate `_transport` field in `IMqttClient.cs` with thread-safety comment
+- **Source:** Adversarial review 20260220-000928, finding F-5
+- **Issue:** The `_transport` field in `MqttClient` (line 150 of `IMqttClient.cs`) is a bare `private IMqttTransport _transport;` with no annotation. All reads must go through the `Transport` property (which uses `Volatile.Read`) to ensure visibility across threads. A missing comment risks future developers reading the field directly, introducing a race condition.
+- **Decision needed:** Add a comment on the field declaration (e.g., `// Reads must use the Transport property (Volatile.Read); writes use Interlocked.Exchange in SwapTransport`) or enforce access through a Roslyn analyzer.
+- **Date parked:** 2026-02-20
+
+### IMPLEMENTATION_PLAN.md Phase 2.5 checkbox desync
+- **Source:** Adversarial review 20260220-000928, finding R-2 (also noted in review-after-iter-03.md)
+- **Issue:** `IMPLEMENTATION_PLAN.md` Phase 2.5 section (Tasks 2.5-A through 2.5-D) still shows `- [ ]` for all Done-when items, while `IMPLEMENTATION_PLAN_PHASE2_5.md` shows all `- [x]`. These should be synchronized.
+- **Decision needed:** Sync during PR merge to `dev`, or as part of Task 1.7?
+- **Date parked:** 2026-02-20

--- a/BACKLOG_PARKING_LOT.md
+++ b/BACKLOG_PARKING_LOT.md
@@ -71,3 +71,31 @@
 - **Issue:** The `release.yaml` workflow builds, signs, and publishes to NuGet.org but does not include a `dotnet test` step. This matches the old Azure DevOps pipeline. The assumption is PR validation already ran tests. Risk: a tag pushed from an untested commit could publish broken packages.
 - **Decision needed:** Accept the current pattern (test in PR only) or add a test step to `release.yaml`? Adding tests costs ~2 minutes per release but prevents publishing broken packages.
 - **Date parked:** 2026-02-19
+
+### Double DISCONNECT injection in Draining→Closing path
+- **Source:** Adversarial review 20260220-000928, finding F-1
+- **Issue:** `TcpTransportActor.BecomeClosing()` unconditionally injects a DISCONNECT packet into the reads channel, but when called from the `Draining` handler after `OutboundFlushed`, a DISCONNECT was already injected at line 546. Two packets enter the reads channel on the graceful drain path.
+- **Decision needed:** Guard `BecomeClosing()` to skip injection if prior state was Draining, or remove the injection from the Draining handler and rely on BecomeClosing.
+- **Date parked:** 2026-02-20
+
+### Remove dead `CompareAndSetStatus` method
+- **Source:** Adversarial review 20260220-000928, finding F-2
+- **Issue:** `TcpTransportActor.ConnectionState.CompareAndSetStatus()` was added for thread-safety but is never called. All status transitions use `Volatile.Write` via the `Status` setter.
+- **Decision needed:** Remove the method or use it where appropriate (e.g., in `DisposeStreamProvider` status assignment).
+- **Date parked:** 2026-02-20
+
+### Propagate `ConnectTimeout` to reconnect CTS
+- **Source:** Adversarial review 20260220-000928, finding F-4
+- **Issue:** `ClientStreamOwner.BeginReconnect()` hardcodes `TimeSpan.FromSeconds(5)` for the reconnect CTS. The new `MqttClientTcpOptions.ConnectTimeout` property is not propagated to the reconnect path.
+- **Decision needed:** Should reconnect timeout match `ConnectTimeout`, be separately configurable, or remain hardcoded?
+- **Date parked:** 2026-02-20
+
+### Add isolated actor test for `ClientStreamOwner.Reconnecting` behavior
+- **Source:** Adversarial review 20260220-000928, finding B-3
+- **Issue:** The `Reconnecting` state in `ClientStreamOwner` is only tested via FakeMqttTcpServer E2E. An isolated TestKit test with TestProbe would verify the message flow (ReconnectSuccess/ReconnectFailed) more reliably and run faster.
+- **Date parked:** 2026-02-20
+
+### Clean up pre-existing `#pragma warning disable CS4014` in MqttClient.ConnectAsync
+- **Source:** Adversarial review 20260220-000928, finding G-4
+- **Issue:** Two instances of fire-and-forget `AbortConnectionAsync()` in `ConnectAsync` error paths use pragma suppression. Should properly track the Task or use a discard with a comment.
+- **Date parked:** 2026-02-20

--- a/BACKLOG_PARKING_LOT.md
+++ b/BACKLOG_PARKING_LOT.md
@@ -44,21 +44,6 @@
 - **Blocked on:** .NET QUIC API stability, MQTT over QUIC standard finalization
 - **Date parked:** 2026-02-19
 
-### TLS support (MQTT 3.1.1 and 5.0)
-- **Source:** Was Task 2.7 and Task 3.12 in `IMPLEMENTATION_PLAN.md`; parked 2026-02-19
-- **Issue:** TLS support exists in-flight on the `tls-support2` branch. The branch has not been reviewed for correctness or compatibility with the current `dev` branch. Task 3.12 (MQTT 5.0 TLS benchmarks) is blocked on this work.
-- **Decision needed:**
-  - Evaluate `tls-support2` branch: merge as-is, merge with modifications, or rewrite?
-  - Is TLS required before a 1.0 release, or is it a post-1.0 feature?
-- **Subtasks when unparked:**
-  - Review `tls-support2` for correctness against current `dev`
-  - Integrate TLS transport: `MqttClientConnectOptions` (certificate, server name, skip-validation for testing)
-  - Container test: connect to EMQX over TLS (port 8883), publish/subscribe at QoS 0 and QoS 1
-  - Unit tests: TLS option validation
-  - `PROJECT_CONTEXT.md` protocol support table: change TLS from "In-flight" to "Implemented"
-  - MQTT 5.0 TLS benchmarks (`Mqtt5TlsTcpBenchmarks.cs`): QoS 0/1, payloads 10 and 1024 bytes, TLS overhead quantified
-- **Date parked:** 2026-02-19
-
 ### AOT compatibility
 - **Source:** `PROJECT_CONTEXT.md` key constraints
 - **Issue:** AOT compilation support is blocked on Akka.NET v1.6 which has not shipped yet. The project currently uses reflection-heavy Akka.NET patterns that are not AOT-friendly.
@@ -78,12 +63,6 @@
 - **Decision needed:** Guard `BecomeClosing()` to skip injection if prior state was Draining, or remove the injection from the Draining handler and rely on BecomeClosing.
 - **Date parked:** 2026-02-20
 
-### Remove dead `CompareAndSetStatus` method
-- **Source:** Adversarial review 20260220-000928, finding F-2
-- **Issue:** `TcpTransportActor.ConnectionState.CompareAndSetStatus()` was added for thread-safety but is never called. All status transitions use `Volatile.Write` via the `Status` setter.
-- **Decision needed:** Remove the method or use it where appropriate (e.g., in `DisposeStreamProvider` status assignment).
-- **Date parked:** 2026-02-20
-
 ### Propagate `ConnectTimeout` to reconnect CTS
 - **Source:** Adversarial review 20260220-000928, finding F-4
 - **Issue:** `ClientStreamOwner.BeginReconnect()` hardcodes `TimeSpan.FromSeconds(5)` for the reconnect CTS. The new `MqttClientTcpOptions.ConnectTimeout` property is not propagated to the reconnect path.
@@ -95,19 +74,3 @@
 - **Issue:** The `Reconnecting` state in `ClientStreamOwner` is only tested via FakeMqttTcpServer E2E. An isolated TestKit test with TestProbe would verify the message flow (ReconnectSuccess/ReconnectFailed) more reliably and run faster.
 - **Date parked:** 2026-02-20
 
-### Clean up pre-existing `#pragma warning disable CS4014` in MqttClient.ConnectAsync
-- **Source:** Adversarial review 20260220-000928, finding G-4
-- **Issue:** Two instances of fire-and-forget `AbortConnectionAsync()` in `ConnectAsync` error paths use pragma suppression. Should properly track the Task or use a discard with a comment.
-- **Date parked:** 2026-02-20
-
-### Annotate `_transport` field in `IMqttClient.cs` with thread-safety comment
-- **Source:** Adversarial review 20260220-000928, finding F-5
-- **Issue:** The `_transport` field in `MqttClient` (line 150 of `IMqttClient.cs`) is a bare `private IMqttTransport _transport;` with no annotation. All reads must go through the `Transport` property (which uses `Volatile.Read`) to ensure visibility across threads. A missing comment risks future developers reading the field directly, introducing a race condition.
-- **Decision needed:** Add a comment on the field declaration (e.g., `// Reads must use the Transport property (Volatile.Read); writes use Interlocked.Exchange in SwapTransport`) or enforce access through a Roslyn analyzer.
-- **Date parked:** 2026-02-20
-
-### IMPLEMENTATION_PLAN.md Phase 2.5 checkbox desync
-- **Source:** Adversarial review 20260220-000928, finding R-2 (also noted in review-after-iter-03.md)
-- **Issue:** `IMPLEMENTATION_PLAN.md` Phase 2.5 section (Tasks 2.5-A through 2.5-D) still shows `- [ ]` for all Done-when items, while `IMPLEMENTATION_PLAN_PHASE2_5.md` shows all `- [x]`. These should be synchronized.
-- **Decision needed:** Sync during PR merge to `dev`, or as part of Task 1.7?
-- **Date parked:** 2026-02-20

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -302,21 +302,21 @@ Introduce `IStreamProvider` + `TcpStreamProvider`, refactor `TcpTransportActor` 
 and replace `new byte[]` allocations in `ReadFromPipeAsync` with `MemoryPool<byte>.Shared.Rent()`.
 
 Done when:
-- [ ] `IStreamProvider` interface exists in `src/TurboMqtt/IO/Tcp/IStreamProvider.cs`
-- [ ] `TcpStreamProvider` implementation exists in `src/TurboMqtt/IO/Tcp/TcpStreamProvider.cs`
-- [ ] `TcpStreamProvider.ConnectAsync()` creates Socket, resolves DNS, connects, returns `NetworkStream`
-- [ ] `TcpTransportActor` constructor takes `IStreamProvider` instead of creating Socket directly
-- [ ] `DoWriteToPipeAsync` reads from `Stream.ReadAsync()` instead of `Socket.ReceiveAsync()`
-- [ ] `DoWriteToSocketAsync` writes to `Stream.WriteAsync()` instead of `Socket.SendAsync()`
-- [ ] `ReadFromPipeAsync` uses `MemoryPool<byte>.Shared.Rent()` instead of `new byte[buffer.Length]`
-- [ ] `UnsharedMemoryOwner` no longer used on the read path (may still be used elsewhere)
-- [ ] `TcpTransport.cs` updated to pass `IStreamProvider` through
-- [ ] `TcpConnectionManager.cs` updated to create appropriate `IStreamProvider`
-- [ ] All existing TCP unit tests pass unchanged
-- [ ] All container tests pass against EMQX
-- [ ] New unit tests for `TcpStreamProvider` (connect, DNS resolution, socket configuration)
-- [ ] BenchmarkDotNet before/after confirms no throughput regression (baseline: 193k msg/sec QoS 0)
-- [ ] Builds with zero warnings
+- [x] `IStreamProvider` interface exists in `src/TurboMqtt/IO/Tcp/IStreamProvider.cs`
+- [x] `TcpStreamProvider` implementation exists in `src/TurboMqtt/IO/Tcp/TcpStreamProvider.cs`
+- [x] `TcpStreamProvider.ConnectAsync()` creates Socket, resolves DNS, connects, returns `NetworkStream`
+- [x] `TcpTransportActor` constructor takes `IStreamProvider` instead of creating Socket directly
+- [x] `DoWriteToPipeAsync` reads from `Stream.ReadAsync()` instead of `Socket.ReceiveAsync()`
+- [x] `DoWriteToSocketAsync` writes to `Stream.WriteAsync()` instead of `Socket.SendAsync()`
+- [x] `ReadFromPipeAsync` uses `MemoryPool<byte>.Shared.Rent()` instead of `new byte[buffer.Length]`
+- [x] `UnsharedMemoryOwner` no longer used on the read path (may still be used elsewhere)
+- [x] `TcpTransport.cs` updated to pass `IStreamProvider` through
+- [x] `TcpConnectionManager.cs` updated to create appropriate `IStreamProvider`
+- [x] All existing TCP unit tests pass unchanged
+- [x] All container tests pass against EMQX
+- [x] New unit tests for `TcpStreamProvider` (connect, DNS resolution, socket configuration)
+- [x] BenchmarkDotNet before/after confirms no throughput regression (baseline: 193k msg/sec QoS 0)
+- [x] Builds with zero warnings
 
 ### Task 2.5-B: Fix transport race conditions
 
@@ -328,22 +328,22 @@ Fix the 12+ identified race conditions in shutdown, reconnection, and transport 
 Can be developed in parallel with Task 2.5-A.
 
 Done when:
-- [ ] `TcpTransportActor` uses explicit `Become` states: `NotStarted → Created → Connecting → Connected → Draining → Closing → Stopped` (and `Aborted` short-circuit)
-- [ ] Background tasks in `BecomeRunning()` tracked with `Task.WhenAll` + `ContinueWith` self-tell `BackgroundTasksCompleted`
-- [ ] `CleanUpGracefully` replaced with state-driven transitions — no more fire-and-forget async
-- [ ] Duplicate `DoClose`/`ReadFinished`/`ConnectionUnexpectedlyClosed` messages in non-handling states are ignored
-- [ ] `MqttClient.SwapTransport()` uses `Interlocked.Exchange` + `volatile` field
-- [ ] TOCTOU on `IsConnected` in `PublishAsync` eliminated — rely on `TryWrite` returning false
-- [ ] `ClientStreamOwner.PostStop()` follows deterministic ordering: complete outbound → abort transport → complete inbound → signal death
-- [ ] `ClientStreamOwner` reconnect uses message-driven `Reconnecting` behavior (no fire-and-forget `DoReconnect`)
-- [ ] `ReadFromPipeAsync` catch block includes `return` after `Tell(ReadFinished.Instance)`
-- [ ] `DisposeSocket` CTS disposal is safe (no double-cancel race with `CleanUpGracefully`)
-- [ ] All existing E2E tests pass
-- [ ] New test: concurrent disconnect + publish does not deadlock or crash
-- [ ] New test: rapid sequential reconnects (3+ in < 1 second) complete without error
-- [ ] New test: server kills connection during QoS 2 exchange — client reconnects and retransmits
-- [ ] New test: disconnect while large publish in flight — verifies graceful drain
-- [ ] Builds with zero warnings
+- [x] `TcpTransportActor` uses explicit `Become` states: `NotStarted → Created → Connecting → Connected → Draining → Closing → Stopped` (and `Aborted` short-circuit)
+- [x] Background tasks in `BecomeRunning()` tracked with `Task.WhenAll` + `ContinueWith` self-tell `BackgroundTasksCompleted`
+- [x] `CleanUpGracefully` replaced with state-driven transitions — no more fire-and-forget async
+- [x] Duplicate `DoClose`/`ReadFinished`/`ConnectionUnexpectedlyClosed` messages in non-handling states are ignored
+- [x] `MqttClient.SwapTransport()` uses `Interlocked.Exchange` + `volatile` field
+- [x] TOCTOU on `IsConnected` in `PublishAsync` eliminated — rely on `TryWrite` returning false
+- [x] `ClientStreamOwner.PostStop()` follows deterministic ordering: complete outbound → abort transport → complete inbound → signal death
+- [x] `ClientStreamOwner` reconnect uses message-driven `Reconnecting` behavior (no fire-and-forget `DoReconnect`)
+- [x] `ReadFromPipeAsync` catch block includes `return` after `Tell(ReadFinished.Instance)`
+- [x] `DisposeSocket` CTS disposal is safe (no double-cancel race with `CleanUpGracefully`)
+- [x] All existing E2E tests pass
+- [x] New test: concurrent disconnect + publish does not deadlock or crash
+- [x] New test: rapid sequential reconnects (3+ in < 1 second) complete without error
+- [x] New test: server kills connection during QoS 2 exchange — client reconnects and retransmits
+- [x] New test: disconnect while large publish in flight — verifies graceful drain
+- [x] Builds with zero warnings
 
 ### Task 2.5-C: Add TLS support via TlsStreamProvider
 
@@ -355,18 +355,18 @@ Done when:
 Implement TLS/SSL support. This is the payoff of the `IStreamProvider` abstraction.
 
 Done when:
-- [ ] `TlsStreamProvider` exists in `src/TurboMqtt/IO/Tcp/TlsStreamProvider.cs`
-- [ ] `TlsStreamProvider.ConnectAsync()` creates Socket → `NetworkStream` → `SslStream`, completes TLS handshake
-- [ ] `MqttClientTlsOptions` public options class exists in `src/TurboMqtt/Client/MqttClientTlsOptions.cs`
-- [ ] `MqttClientTlsOptions` supports: `ClientCertificates`, `ServerCertificateValidationCallback`, `EnabledSslProtocols`, `TargetHost`
-- [ ] `IMqttClientFactory.CreateTlsTcpClient()` factory method added
-- [ ] `TcpMqttTransportManager` accepts optional TLS options and creates appropriate `IStreamProvider`
-- [ ] Container test: connect to EMQX over TLS (port 8883) and publish/subscribe at QoS 0
-- [ ] Container test: connect to EMQX over TLS and publish/subscribe at QoS 1
-- [ ] Container test: TLS with custom `ServerCertificateValidationCallback` for self-signed certs
-- [ ] All existing TCP tests still pass (no regression)
-- [ ] `PROJECT_CONTEXT.md` protocol support table updated: TLS status changed from "In-flight" to "Implemented"
-- [ ] Builds with zero warnings
+- [x] `TlsStreamProvider` exists in `src/TurboMqtt/IO/Tcp/TlsStreamProvider.cs`
+- [x] `TlsStreamProvider.ConnectAsync()` creates Socket → `NetworkStream` → `SslStream`, completes TLS handshake
+- [x] `MqttClientTlsOptions` public options class exists in `src/TurboMqtt/Client/MqttClientTlsOptions.cs`
+- [x] `MqttClientTlsOptions` supports: `ClientCertificates`, `ServerCertificateValidationCallback`, `EnabledSslProtocols`, `TargetHost`
+- [x] `IMqttClientFactory.CreateTlsTcpClient()` factory method added
+- [x] `TcpMqttTransportManager` accepts optional TLS options and creates appropriate `IStreamProvider`
+- [x] Container test: connect to EMQX over TLS (port 8883) and publish/subscribe at QoS 0
+- [x] Container test: connect to EMQX over TLS and publish/subscribe at QoS 1
+- [x] Container test: TLS with custom `ServerCertificateValidationCallback` for self-signed certs
+- [x] All existing TCP tests still pass (no regression)
+- [x] `PROJECT_CONTEXT.md` protocol support table updated: TLS status changed from "In-flight" to "Implemented"
+- [x] Builds with zero warnings
 
 ### Task 2.5-D: Transport lifecycle hardening
 
@@ -378,16 +378,16 @@ Done when:
 Formalize the transport state machine and graceful drain to production quality.
 
 Done when:
-- [ ] Full FSM with explicit state transitions and structured logging at each transition
-- [ ] `ConnectionState` shared mutable state replaced with actor messages or thread-safe wrappers
-- [ ] Graceful drain: `Draining` state where outbound flushes before DISCONNECT is sent
-- [ ] Connect timeout with cancellation propagation (configurable, default 10s)
-- [ ] Actor test: verify all state transitions with TestProbe (`NotStarted → Created → Connecting → Connected → Draining → Closing → Stopped`)
-- [ ] Actor test: verify `Aborted` short-circuit path
-- [ ] Test: disconnect while large publish in flight — outbound flushes before close
-- [ ] Test: connect timeout fires when broker is unreachable
-- [ ] All E2E tests pass
-- [ ] Builds with zero warnings
+- [x] Full FSM with explicit state transitions and structured logging at each transition
+- [x] `ConnectionState` shared mutable state replaced with actor messages or thread-safe wrappers
+- [x] Graceful drain: `Draining` state where outbound flushes before DISCONNECT is sent
+- [x] Connect timeout with cancellation propagation (configurable, default 10s)
+- [x] Actor test: verify all state transitions with TestProbe (`NotStarted → Created → Connecting → Connected → Draining → Closing → Stopped`)
+- [x] Actor test: verify `Aborted` short-circuit path
+- [x] Test: disconnect while large publish in flight — outbound flushes before close
+- [x] Test: connect timeout fires when broker is unreachable
+- [x] All E2E tests pass
+- [x] Builds with zero warnings
 
 ---
 

--- a/IMPLEMENTATION_PLAN_PHASE2_5.md
+++ b/IMPLEMENTATION_PLAN_PHASE2_5.md
@@ -29,21 +29,21 @@ Introduce `IStreamProvider` + `TcpStreamProvider`, refactor `TcpTransportActor` 
 and replace `new byte[]` allocations in `ReadFromPipeAsync` with `MemoryPool<byte>.Shared.Rent()`.
 
 Done when:
-- [ ] `IStreamProvider` interface exists in `src/TurboMqtt/IO/Tcp/IStreamProvider.cs`
-- [ ] `TcpStreamProvider` implementation exists in `src/TurboMqtt/IO/Tcp/TcpStreamProvider.cs`
-- [ ] `TcpStreamProvider.ConnectAsync()` creates Socket, resolves DNS, connects, returns `NetworkStream`
-- [ ] `TcpTransportActor` constructor takes `IStreamProvider` instead of creating Socket directly
-- [ ] `DoWriteToPipeAsync` reads from `Stream.ReadAsync()` instead of `Socket.ReceiveAsync()`
-- [ ] `DoWriteToSocketAsync` writes to `Stream.WriteAsync()` instead of `Socket.SendAsync()`
-- [ ] `ReadFromPipeAsync` uses `MemoryPool<byte>.Shared.Rent()` instead of `new byte[buffer.Length]`
-- [ ] `UnsharedMemoryOwner` no longer used on the read path (may still be used elsewhere)
-- [ ] `TcpTransport.cs` updated to pass `IStreamProvider` through
-- [ ] `TcpConnectionManager.cs` updated to create appropriate `IStreamProvider`
-- [ ] All existing TCP unit tests pass unchanged
+- [x] `IStreamProvider` interface exists in `src/TurboMqtt/IO/Tcp/IStreamProvider.cs`
+- [x] `TcpStreamProvider` implementation exists in `src/TurboMqtt/IO/Tcp/TcpStreamProvider.cs`
+- [x] `TcpStreamProvider.ConnectAsync()` creates Socket, resolves DNS, connects, returns `NetworkStream`
+- [x] `TcpTransportActor` constructor takes `IStreamProvider` instead of creating Socket directly
+- [x] `DoWriteToPipeAsync` reads from `Stream.ReadAsync()` instead of `Socket.ReceiveAsync()`
+- [x] `DoWriteToSocketAsync` writes to `Stream.WriteAsync()` instead of `Socket.SendAsync()`
+- [x] `ReadFromPipeAsync` uses `MemoryPool<byte>.Shared.Rent()` instead of `new byte[buffer.Length]`
+- [x] `UnsharedMemoryOwner` no longer used on the read path (may still be used elsewhere)
+- [x] `TcpTransport.cs` updated to pass `IStreamProvider` through
+- [x] `TcpConnectionManager.cs` updated to create appropriate `IStreamProvider`
+- [x] All existing TCP unit tests pass unchanged
 - [ ] All container tests pass against EMQX
-- [ ] New unit tests for `TcpStreamProvider` (connect, DNS resolution, socket configuration)
+- [x] New unit tests for `TcpStreamProvider` (connect, DNS resolution, socket configuration)
 - [ ] BenchmarkDotNet before/after confirms no throughput regression (baseline: 193k msg/sec QoS 0)
-- [ ] Builds with zero warnings
+- [x] Builds with zero warnings
 
 ### Task 2.5-B: Fix transport race conditions
 

--- a/IMPLEMENTATION_PLAN_PHASE2_5.md
+++ b/IMPLEMENTATION_PLAN_PHASE2_5.md
@@ -9,6 +9,19 @@
 
 ---
 
+### FIX: Add missing F-5 PARK item to BACKLOG_PARKING_LOT.md
+
+**Source:** Adversarial review 20260220-000928 iter-06, finding R-1
+**Surface area:** documentation
+**Verification:** L0
+
+The prior review's finding F-5 (`_transport` field visibility in `IMqttClient.cs`) was dispositioned as PARK but not added to the parking lot.
+
+Done when:
+- [x] `BACKLOG_PARKING_LOT.md` has an entry for F-5: `_transport` field in `IMqttClient.cs` should be annotated with a comment noting that reads must go through the `Transport` property (which uses `Volatile.Read`)
+
+---
+
 ### FIX: Add logging for failed resubscribe during reconnect
 
 **Source:** Adversarial review 20260220-000928, finding F-3

--- a/IMPLEMENTATION_PLAN_PHASE2_5.md
+++ b/IMPLEMENTATION_PLAN_PHASE2_5.md
@@ -55,22 +55,22 @@ Fix the 12+ identified race conditions in shutdown, reconnection, and transport 
 Can be developed in parallel with Task 2.5-A.
 
 Done when:
-- [ ] `TcpTransportActor` uses explicit `Become` states: `NotStarted → Created → Connecting → Connected → Draining → Closing → Stopped` (and `Aborted` short-circuit)
-- [ ] Background tasks in `BecomeRunning()` tracked with `Task.WhenAll` + `ContinueWith` self-tell `BackgroundTasksCompleted`
-- [ ] `CleanUpGracefully` replaced with state-driven transitions — no more fire-and-forget async
-- [ ] Duplicate `DoClose`/`ReadFinished`/`ConnectionUnexpectedlyClosed` messages in non-handling states are ignored
-- [ ] `MqttClient.SwapTransport()` uses `Interlocked.Exchange` + `volatile` field
-- [ ] TOCTOU on `IsConnected` in `PublishAsync` eliminated — rely on `TryWrite` returning false
-- [ ] `ClientStreamOwner.PostStop()` follows deterministic ordering: complete outbound → abort transport → complete inbound → signal death
-- [ ] `ClientStreamOwner` reconnect uses message-driven `Reconnecting` behavior (no fire-and-forget `DoReconnect`)
-- [ ] `ReadFromPipeAsync` catch block includes `return` after `Tell(ReadFinished.Instance)`
-- [ ] `DisposeSocket` CTS disposal is safe (no double-cancel race with `CleanUpGracefully`)
-- [ ] All existing E2E tests pass
-- [ ] New test: concurrent disconnect + publish does not deadlock or crash
-- [ ] New test: rapid sequential reconnects (3+ in < 1 second) complete without error
-- [ ] New test: server kills connection during QoS 2 exchange — client reconnects and retransmits
-- [ ] New test: disconnect while large publish in flight — verifies graceful drain
-- [ ] Builds with zero warnings
+- [x] `TcpTransportActor` uses explicit `Become` states: `NotStarted → Created → Connecting → Connected → Draining → Closing → Stopped` (and `Aborted` short-circuit)
+- [x] Background tasks in `BecomeRunning()` tracked with `Task.WhenAll` + `ContinueWith` self-tell `BackgroundTasksCompleted`
+- [x] `CleanUpGracefully` replaced with state-driven transitions — no more fire-and-forget async
+- [x] Duplicate `DoClose`/`ReadFinished`/`ConnectionUnexpectedlyClosed` messages in non-handling states are ignored
+- [x] `MqttClient.SwapTransport()` uses `Interlocked.Exchange` + `volatile` field
+- [x] TOCTOU on `IsConnected` in `PublishAsync` eliminated — rely on `TryWrite` returning false
+- [x] `ClientStreamOwner.PostStop()` follows deterministic ordering: complete outbound → abort transport → complete inbound → signal death
+- [x] `ClientStreamOwner` reconnect uses message-driven `Reconnecting` behavior (no fire-and-forget `DoReconnect`)
+- [x] `ReadFromPipeAsync` catch block includes `return` after `Tell(ReadFinished.Instance)`
+- [x] `DisposeSocket` CTS disposal is safe (no double-cancel race with `CleanUpGracefully`)
+- [x] All existing E2E tests pass
+- [x] New test: concurrent disconnect + publish does not deadlock or crash
+- [x] New test: rapid sequential reconnects (3+ in < 1 second) complete without error
+- [x] New test: server kills connection during QoS 2 exchange — client reconnects and retransmits
+- [x] New test: disconnect while large publish in flight — verifies graceful drain
+- [x] Builds with zero warnings
 
 ### Task 2.5-C: Add TLS support via TlsStreamProvider
 

--- a/IMPLEMENTATION_PLAN_PHASE2_5.md
+++ b/IMPLEMENTATION_PLAN_PHASE2_5.md
@@ -82,18 +82,18 @@ Done when:
 Implement TLS/SSL support. This is the payoff of the `IStreamProvider` abstraction.
 
 Done when:
-- [ ] `TlsStreamProvider` exists in `src/TurboMqtt/IO/Tcp/TlsStreamProvider.cs`
-- [ ] `TlsStreamProvider.ConnectAsync()` creates Socket → `NetworkStream` → `SslStream`, completes TLS handshake
-- [ ] `MqttClientTlsOptions` public options class exists in `src/TurboMqtt/Client/MqttClientTlsOptions.cs`
-- [ ] `MqttClientTlsOptions` supports: `ClientCertificates`, `ServerCertificateValidationCallback`, `EnabledSslProtocols`, `TargetHost`
-- [ ] `IMqttClientFactory.CreateTlsTcpClient()` factory method added
-- [ ] `TcpMqttTransportManager` accepts optional TLS options and creates appropriate `IStreamProvider`
-- [ ] Container test: connect to EMQX over TLS (port 8883) and publish/subscribe at QoS 0
-- [ ] Container test: connect to EMQX over TLS and publish/subscribe at QoS 1
-- [ ] Container test: TLS with custom `ServerCertificateValidationCallback` for self-signed certs
-- [ ] All existing TCP tests still pass (no regression)
-- [ ] `PROJECT_CONTEXT.md` protocol support table updated: TLS status changed from "In-flight" to "Implemented"
-- [ ] Builds with zero warnings
+- [x] `TlsStreamProvider` exists in `src/TurboMqtt/IO/Tcp/TlsStreamProvider.cs`
+- [x] `TlsStreamProvider.ConnectAsync()` creates Socket → `NetworkStream` → `SslStream`, completes TLS handshake
+- [x] `MqttClientTlsOptions` public options class exists in `src/TurboMqtt/Client/MqttClientTlsOptions.cs`
+- [x] `MqttClientTlsOptions` supports: `ClientCertificates`, `ServerCertificateValidationCallback`, `EnabledSslProtocols`, `TargetHost`
+- [x] `IMqttClientFactory.CreateTlsTcpClient()` factory method added
+- [x] `TcpMqttTransportManager` accepts optional TLS options and creates appropriate `IStreamProvider`
+- [x] Container test: connect to EMQX over TLS (port 8883) and publish/subscribe at QoS 0
+- [x] Container test: connect to EMQX over TLS and publish/subscribe at QoS 1
+- [x] Container test: TLS with custom `ServerCertificateValidationCallback` for self-signed certs
+- [x] All existing TCP tests still pass (no regression)
+- [x] `PROJECT_CONTEXT.md` protocol support table updated: TLS status changed from "In-flight" to "Implemented"
+- [x] Builds with zero warnings
 
 ### Task 2.5-D: Transport lifecycle hardening
 

--- a/IMPLEMENTATION_PLAN_PHASE2_5.md
+++ b/IMPLEMENTATION_PLAN_PHASE2_5.md
@@ -9,34 +9,6 @@
 
 ---
 
-### FIX: Add missing F-5 PARK item to BACKLOG_PARKING_LOT.md
-
-**Source:** Adversarial review 20260220-000928 iter-06, finding R-1
-**Surface area:** documentation
-**Verification:** L0
-
-The prior review's finding F-5 (`_transport` field visibility in `IMqttClient.cs`) was dispositioned as PARK but not added to the parking lot.
-
-Done when:
-- [x] `BACKLOG_PARKING_LOT.md` has an entry for F-5: `_transport` field in `IMqttClient.cs` should be annotated with a comment noting that reads must go through the `Transport` property (which uses `Volatile.Read`)
-
----
-
-### FIX: Add logging for failed resubscribe during reconnect
-
-**Source:** Adversarial review 20260220-000928, finding F-3
-**Surface area:** cross-cutting
-**Verification:** L1
-
-The empty `if (!subscribeResp.IsSuccess) { }` block in `BeginReconnect()` silently swallows
-subscription failures during reconnect. At minimum, log the failure.
-
-Done when:
-- [x] `ClientStreamOwner.cs` `BeginReconnect()` method: add `_log.Warning(...)` inside the `if (!subscribeResp.IsSuccess)` block reporting the failure reason and number of topics
-- [x] Builds with zero warnings
-
----
-
 ## Phase 2.5: Transport Layer Redesign
 
 > Goal: Fix 12+ race conditions in the transport/lifecycle layer, eliminate GC pressure

--- a/IMPLEMENTATION_PLAN_PHASE2_5.md
+++ b/IMPLEMENTATION_PLAN_PHASE2_5.md
@@ -9,6 +9,21 @@
 
 ---
 
+### FIX: Add logging for failed resubscribe during reconnect
+
+**Source:** Adversarial review 20260220-000928, finding F-3
+**Surface area:** cross-cutting
+**Verification:** L1
+
+The empty `if (!subscribeResp.IsSuccess) { }` block in `BeginReconnect()` silently swallows
+subscription failures during reconnect. At minimum, log the failure.
+
+Done when:
+- [x] `ClientStreamOwner.cs` `BeginReconnect()` method: add `_log.Warning(...)` inside the `if (!subscribeResp.IsSuccess)` block reporting the failure reason and number of topics
+- [x] Builds with zero warnings
+
+---
+
 ## Phase 2.5: Transport Layer Redesign
 
 > Goal: Fix 12+ race conditions in the transport/lifecycle layer, eliminate GC pressure

--- a/IMPLEMENTATION_PLAN_PHASE2_5.md
+++ b/IMPLEMENTATION_PLAN_PHASE2_5.md
@@ -105,16 +105,16 @@ Done when:
 Formalize the transport state machine and graceful drain to production quality.
 
 Done when:
-- [ ] Full FSM with explicit state transitions and structured logging at each transition
-- [ ] `ConnectionState` shared mutable state replaced with actor messages or thread-safe wrappers
-- [ ] Graceful drain: `Draining` state where outbound flushes before DISCONNECT is sent
-- [ ] Connect timeout with cancellation propagation (configurable, default 10s)
-- [ ] Actor test: verify all state transitions with TestProbe (`NotStarted → Created → Connecting → Connected → Draining → Closing → Stopped`)
-- [ ] Actor test: verify `Aborted` short-circuit path
-- [ ] Test: disconnect while large publish in flight — outbound flushes before close
-- [ ] Test: connect timeout fires when broker is unreachable
-- [ ] All E2E tests pass
-- [ ] Builds with zero warnings
+- [x] Full FSM with explicit state transitions and structured logging at each transition
+- [x] `ConnectionState` shared mutable state replaced with actor messages or thread-safe wrappers
+- [x] Graceful drain: `Draining` state where outbound flushes before DISCONNECT is sent
+- [x] Connect timeout with cancellation propagation (configurable, default 10s)
+- [x] Actor test: verify all state transitions with TestProbe (`NotStarted → Created → Connecting → Connected → Draining → Closing → Stopped`)
+- [x] Actor test: verify `Aborted` short-circuit path
+- [x] Test: disconnect while large publish in flight — outbound flushes before close
+- [x] Test: connect timeout fires when broker is unreachable
+- [x] All E2E tests pass
+- [x] Builds with zero warnings
 
 ---
 

--- a/IMPLEMENTATION_PLAN_PHASE2_5.md
+++ b/IMPLEMENTATION_PLAN_PHASE2_5.md
@@ -40,9 +40,9 @@ Done when:
 - [x] `TcpTransport.cs` updated to pass `IStreamProvider` through
 - [x] `TcpConnectionManager.cs` updated to create appropriate `IStreamProvider`
 - [x] All existing TCP unit tests pass unchanged
-- [ ] All container tests pass against EMQX
+- [x] All container tests pass against EMQX
 - [x] New unit tests for `TcpStreamProvider` (connect, DNS resolution, socket configuration)
-- [ ] BenchmarkDotNet before/after confirms no throughput regression (baseline: 193k msg/sec QoS 0)
+- [x] BenchmarkDotNet before/after confirms no throughput regression (baseline: 193k msg/sec QoS 0)
 - [x] Builds with zero warnings
 
 ### Task 2.5-B: Fix transport race conditions

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -47,7 +47,7 @@ ActorSystem
 | MQTT 3.1.1 | Implemented (production hardening in progress) |
 | MQTT 5.0 | Packet infrastructure exists; not yet functional |
 | MQTT over QUIC | Roadmap only |
-| TLS | In-flight (draft PRs #123, #182) |
+| TLS | Implemented (via `TlsStreamProvider` + `MqttClientTlsOptions`) |
 
 ### Key Constraints
 
@@ -62,7 +62,7 @@ ActorSystem
 - **Version**: 0.2.0 (pre-1.0, last release June 2024)
 - **Priority**: MQTT 3.1.1 production readiness (epic #66)
 - **Known issues**: CI/CD GitHub Release broken (#74), flaky test (#99), dependabot PR backlog
-- **In-flight features**: TLS support, AOT canary, decoder perf optimization
+- **In-flight features**: AOT canary, decoder perf optimization
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ TurboMqtt is written on top of [Akka.NET](https://getakka.net/) and Akka.Streams
 * Automatic retry-reconnect in broker disconnect scenarios;
 * Full support for IAsyncEnumerable and backpressure on the receiver side;
 * Automatically de-duplicates packets on the receiver side; and
-* Automatically acks QoS 1 and QoS 2 packets.
+* Automatically acks QoS 1 and QoS 2 packets; and
+* TLS/SSL support with mutual TLS and custom certificate validation.
 
 Simple interface that works at very high rates of speed with minimal resource utilization.
 
@@ -89,6 +90,37 @@ if (!connectResult.IsSuccess)
         connectResult.Reason);
     return;
 }
+```
+
+### Enabling TLS
+
+To connect to a broker over TLS (port 8883), use `CreateTlsTcpClient` instead of `CreateTcpClient`:
+
+```csharp
+var tcpClientOptions = new MqttClientTcpOptions(config.Host, 8883);
+var clientConnectOptions = new MqttClientConnectOptions(config.ClientId, MqttProtocolVersion.V3_1_1)
+{
+    UserName = config.User,
+    Password = config.Password
+};
+
+// default TLS options — uses system CA validation and TLS 1.2+
+var tlsOptions = new MqttClientTlsOptions();
+
+await using IMqttClient client = await _clientFactory.CreateTlsTcpClient(clientConnectOptions, tcpClientOptions, tlsOptions);
+```
+
+For self-signed brokers or mutual TLS:
+
+```csharp
+var tlsOptions = new MqttClientTlsOptions
+{
+    // accept self-signed certificates (development only!)
+    ServerCertificateValidationCallback = (sender, cert, chain, errors) => true,
+
+    // mutual TLS with client certificate
+    ClientCertificates = new X509CertificateCollection { clientCert },
+};
 ```
 
 ### Publishing Messages

--- a/src/TurboMqtt/Client/ClientStreamOwner.cs
+++ b/src/TurboMqtt/Client/ClientStreamOwner.cs
@@ -560,7 +560,8 @@ internal sealed class ClientStreamOwner : UntypedActor
                         var subscribeResp = await client.SubscribeAsync(savedSubs.Values.ToArray(), reconnectToken);
                         if (!subscribeResp.IsSuccess)
                         {
-                            // non-fatal: log and continue
+                            _log.Warning("Failed to resubscribe to {0} topic(s) during reconnect. Reason: {1}",
+                                savedSubs.Count, subscribeResp.Reason);
                         }
                     }
 

--- a/src/TurboMqtt/Client/ClientStreamOwner.cs
+++ b/src/TurboMqtt/Client/ClientStreamOwner.cs
@@ -63,6 +63,23 @@ internal sealed class ClientStreamOwner : UntypedActor
         public static readonly StreamTerminated Instance = new();
     }
 
+    /// <summary>
+    /// Self-tell: reconnect completed successfully.
+    /// </summary>
+    private sealed class ReconnectSuccess : IClientStreamOwnerMessage
+    {
+        private ReconnectSuccess()
+        {
+        }
+
+        public static readonly ReconnectSuccess Instance = new();
+    }
+
+    /// <summary>
+    /// Self-tell: reconnect failed.
+    /// </summary>
+    private sealed record ReconnectFailed(string Reason) : IClientStreamOwnerMessage;
+
     public sealed class TransportConnectedSuccessfully : IClientStreamOwnerMessage
     {
         private TransportConnectedSuccessfully()
@@ -113,6 +130,7 @@ internal sealed class ClientStreamOwner : UntypedActor
     private readonly TaskCompletionSource<DisconnectReasonCode> _trueDeath = new();
 
     private readonly ILoggingAdapter _log = Context.GetLogger();
+    private readonly IActorRef _closureSelf = Context.Self;
 
     /* Data we need for automatic reconnects */
     private MqttClientConnectOptions? _connectOptions;
@@ -120,6 +138,7 @@ internal sealed class ClientStreamOwner : UntypedActor
     private int _remainingReconnectAttempts = 3;
     private int _streamOperatorId = 0;
     private bool _successfullyConnected = false;
+    private CancellationTokenSource? _reconnectCts;
 
     protected override void OnReceive(object message)
     {
@@ -320,94 +339,17 @@ internal sealed class ClientStreamOwner : UntypedActor
                 break;
             }
 
-            // old stream is dead, time to create a new one
+            // old stream is dead, time to create a new one — enter Reconnecting behavior
             case StreamTerminated when _successfullyConnected:
             {
                 if (_remainingReconnectAttempts <= 0)
                     return; // ignore
 
-                RunTask(async () =>
-                {
-                    _remainingReconnectAttempts--;
-
-                    // TODO: determine if this is an irrecoverable broker error
-                    // if it is, we need to shut down the client
-                    // if it's not, we need to reconnect
-
-                    await ReplaceTransport();
-
-                    var requiredActors = new MqttRequiredActors(_exactlyOnceActor!, _atLeastOnceActor!,
-                        _clientAckActor!,
-                        _heartBeatActor!);
-
-                    // the transport should be at rest now, no longer being written to - clear out all the old data\
-                    HashSet<MqttPacket> preservedPackets = new();
-                    while (_outboundChannel!.Reader.TryRead(out var p))
-                    {
-                        if (p.PacketType == MqttPacketType.Disconnect)
-                            continue; // don't bother resending disconnect packets
-                        preservedPackets.Add(p);
-                    }
-
-                    _log.Debug("Preserved {0} packets for retransmission.", preservedPackets.Count);
-
-                    // NOTE: inbound channel does not need to be drained - it's a one-way channel
-
-                    // need to reconnect the streams
-                    var streamCreateResult = await PrepareStreamAsync(_connectOptions!, _currentTransport!,
-                        _outboundChannel!, _inboundChannel!, requiredActors, Self);
-
-                    if (!streamCreateResult.IsSuccess) // should never happen
-                    {
-                        var errMsg = $"Failed to recreate stream. Reason: {streamCreateResult.ReasonString}";
-                        _log.Error(errMsg);
-                        Self.Tell(PoisonPill.Instance);
-                        return;
-                    }
-
-                    var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-                    _ = DoReconnect(preservedPackets, cts.Token);
-                });
-
+                _remainingReconnectAttempts--;
+                _log.Info("Stream terminated. Entering Reconnecting state. Remaining attempts: {0}", _remainingReconnectAttempts);
+                Become(Reconnecting);
+                BeginReconnect();
                 break;
-
-                // reconnect the client using the client with the new transport
-                async Task DoReconnect(HashSet<MqttPacket> preserved, CancellationToken ct)
-                {
-                    var self = Self;
-                    try
-                    {
-                        var resp = await _client!.ConnectAsync(ct);
-                        if (!resp.IsSuccess)
-                        {
-                            _log.Warning("Failed to reconnect client. Reason: {0}", resp.Reason);
-                            self.Tell(new ServerDisconnect(new DisconnectPacket()
-                                { ReasonCode = DisconnectReasonCode.MaximumConnectTime }));
-                        }
-
-                        // for each of our subscriptions, we need to resubscribe
-                        var subscribeResp = await _client.SubscribeAsync(_savedSubscriptions.Values.ToArray(), ct);
-                        if (!subscribeResp.IsSuccess)
-                        {
-                            _log.Warning("Failed to resubscribe to topics. Reason: {0}", subscribeResp.Reason);
-                            self.Tell(new ServerDisconnect(new DisconnectPacket()
-                                { ReasonCode = DisconnectReasonCode.UnspecifiedError }));
-                        }
-                        
-                        // reset the reconnect attempts
-                        self.Tell(TransportConnectedSuccessfully.Instance);
-
-                        // requeue all the packets that were preserved
-                        foreach (var p in preserved)
-                            _outboundChannel.Writer.TryWrite(p);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        _log.Warning("Reconnect operation timed out. Aborting transport.");
-                        // ReSharper disable once MethodSupportsCancellation
-                        _ = _currentTransport!.AbortAsync(ct);
-                    }
-                }
             }
 
             case DoDisconnect doDisconnect: // explicit disconnect - no coming back from this
@@ -457,6 +399,81 @@ internal sealed class ClientStreamOwner : UntypedActor
         }
     }
 
+    /// <summary>
+    /// Message-driven reconnection state.
+    /// Waits for <see cref="ReconnectSuccess"/> or <see cref="ReconnectFailed"/> self-tells.
+    /// </summary>
+    private void Reconnecting(object message)
+    {
+        switch (message)
+        {
+            case ReconnectSuccess:
+            {
+                _log.Info("Reconnect succeeded. Returning to Running state.");
+                _closureSelf.Tell(TransportConnectedSuccessfully.Instance);
+                Become(Running);
+                break;
+            }
+            case ReconnectFailed failed:
+            {
+                _log.Warning("Reconnect failed: {0}", failed.Reason);
+                if (_remainingReconnectAttempts > 0)
+                {
+                    _remainingReconnectAttempts--;
+                    _log.Info("Retrying reconnect. Remaining attempts: {0}", _remainingReconnectAttempts);
+                    BeginReconnect();
+                }
+                else
+                {
+                    _log.Info("Client has exhausted all reconnect attempts. Shutting down.");
+                    Self.Tell(PoisonPill.Instance);
+                }
+                break;
+            }
+            case TransportFailedToConnect:
+            {
+                // Respond to unblock MqttClient.ConnectAsync's Ask<TransportResetComplete>
+                Sender.Tell(TransportResetComplete.Instance);
+                break;
+            }
+            case TransportConnectedSuccessfully:
+            {
+                // Sent by MqttClient.ConnectAsync during reconnect — ignore here,
+                // we send our own after ReconnectSuccess
+                break;
+            }
+            case ServerDisconnect:
+            {
+                // Transport died during reconnect — cancel the in-flight ConnectAsync
+                // so it fails immediately instead of waiting for the full CTS timeout.
+                _log.Debug("Cancelling reconnect due to ServerDisconnect.");
+                _reconnectCts?.Cancel();
+                break;
+            }
+            case StreamTerminated:
+                _log.Debug("Ignoring StreamTerminated in Reconnecting state.");
+                break;
+            case DoDisconnect:
+            {
+                _log.Info("Received disconnect request while reconnecting. Shutting down.");
+                Sender.Tell(DisconnectComplete.Instance);
+                Self.Tell(PoisonPill.Instance);
+                break;
+            }
+            case Terminated t:
+            {
+                _log.Error(
+                    "One of the required actors [{0}] has terminated during reconnect. Shutting down the client.",
+                    t.ActorRef);
+                Self.Tell(PoisonPill.Instance);
+                break;
+            }
+            default:
+                Unhandled(message);
+                break;
+        }
+    }
+
     private async Task ReplaceTransport()
     {
         CreateStreamInstanceOwner();
@@ -466,25 +483,122 @@ internal sealed class ClientStreamOwner : UntypedActor
 
         // swap transports
         _client!.SwapTransport(_currentTransport);
-        
+
         // Reset the ack actor connection state
         _clientAckActor!.Tell(ClientAcksActor.Reconnect.Instance);
     }
 
+    /// <summary>
+    /// Starts a reconnect attempt. Creates a new CTS, cleans up old resources,
+    /// sets up new transport/stream, and launches ConnectAsync on the thread pool.
+    /// </summary>
+    private void BeginReconnect()
+    {
+        _reconnectCts?.Cancel();
+        _reconnectCts?.Dispose();
+        _reconnectCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var reconnectToken = _reconnectCts.Token;
+
+        RunTask(async () =>
+        {
+            // Clean up old stream instance (may already be dead, that's fine)
+            if (_streamInstanceOwner != null)
+            {
+                Context.Unwatch(_streamInstanceOwner);
+                Context.Stop(_streamInstanceOwner);
+            }
+
+            _ = _currentTransport?.AbortAsync();
+            _currentTransport = null;
+
+            await ReplaceTransport();
+
+            var requiredActors = new MqttRequiredActors(_exactlyOnceActor!, _atLeastOnceActor!,
+                _clientAckActor!, _heartBeatActor!);
+
+            // the transport should be at rest now — clear out old data
+            HashSet<MqttPacket> preservedPackets = new();
+            while (_outboundChannel!.Reader.TryRead(out var p))
+            {
+                if (p.PacketType == MqttPacketType.Disconnect)
+                    continue; // don't bother resending disconnect packets
+                preservedPackets.Add(p);
+            }
+
+            _log.Debug("Preserved {0} packets for retransmission.", preservedPackets.Count);
+
+            // need to reconnect the streams
+            var streamCreateResult = await PrepareStreamAsync(_connectOptions!, _currentTransport!,
+                _outboundChannel!, _inboundChannel!, requiredActors, Self);
+
+            if (!streamCreateResult.IsSuccess)
+            {
+                _closureSelf.Tell(new ReconnectFailed($"Failed to recreate stream. Reason: {streamCreateResult.ReasonString}"));
+                return;
+            }
+
+            // Phase 2: Run ConnectAsync on the thread pool so the actor can process
+            // messages (like TransportFailedToConnect) that ConnectAsync sends back.
+            var closureSelf = _closureSelf;
+            var client = _client!;
+            var savedSubs = _savedSubscriptions;
+            var outbound = _outboundChannel!;
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    var resp = await client.ConnectAsync(reconnectToken);
+                    if (!resp.IsSuccess)
+                    {
+                        closureSelf.Tell(new ReconnectFailed($"Failed to reconnect. Reason: {resp.Reason}"));
+                        return;
+                    }
+
+                    // resubscribe
+                    if (savedSubs.Count > 0)
+                    {
+                        var subscribeResp = await client.SubscribeAsync(savedSubs.Values.ToArray(), reconnectToken);
+                        if (!subscribeResp.IsSuccess)
+                        {
+                            // non-fatal: log and continue
+                        }
+                    }
+
+                    // requeue preserved packets
+                    foreach (var pk in preservedPackets)
+                        outbound.Writer.TryWrite(pk);
+
+                    closureSelf.Tell(ReconnectSuccess.Instance);
+                }
+                catch (OperationCanceledException)
+                {
+                    closureSelf.Tell(new ReconnectFailed("Reconnect operation timed out or was cancelled."));
+                }
+            });
+        });
+    }
+
     protected override void PostStop()
     {
-        // force the transport to close - usually it will already be dead by now
-        _currentTransport?.AbortAsync();
-        
-        // subtle race condition - if someone immediately tries to recreate a failed client, our parent
-        // might yell at them and say "client already exists" - this is because DeathWatch runs slightly
-        // behind the _trueDeath task completion even when it runs only in our PostStop routine.
-        // Thus, we're going to front-run DeathWatch here and tell our parent that we're dead.
-        Context.Parent.Tell(new ClientManagerActor.ClientDied(_connectOptions!.ClientId));
+        // Cancel and dispose reconnect CTS
+        _reconnectCts?.Cancel();
+        _reconnectCts?.Dispose();
 
-        // force both channels to complete - this will shut down the streams and the transport
+        // Deterministic shutdown ordering:
+        // 1. Complete outbound channel writer — stops new data entering stream
         _outboundChannel?.Writer.TryComplete();
+
+        // 2. Abort transport — cancels background tasks, disposes stream
+        _currentTransport?.AbortAsync();
+
+        // 3. Complete inbound channel writer — terminates consumer
         _inboundChannel?.Writer.TryComplete();
+
+        // 4. Signal _trueDeath — unblocks WhenTerminated
         _trueDeath.TrySetResult(DisconnectReasonCode.NormalDisconnection);
+
+        // 5. Tell parent that we're dead — front-runs DeathWatch to avoid
+        //    "client already exists" race if someone immediately recreates.
+        Context.Parent.Tell(new ClientManagerActor.ClientDied(_connectOptions!.ClientId));
     }
 }

--- a/src/TurboMqtt/Client/IMqttClient.cs
+++ b/src/TurboMqtt/Client/IMqttClient.cs
@@ -154,6 +154,11 @@ public sealed class MqttClient : IInternalMqttClient
     private readonly ILoggingAdapter _log;
     private readonly UShortCounter _packetIdCounter = new();
 
+    /// <summary>
+    /// Thread-safe read of the current transport.
+    /// </summary>
+    private IMqttTransport Transport => Volatile.Read(ref _transport);
+
     internal MqttClient(IMqttTransport transport, IActorRef clientOwner, MqttRequiredActors requiredActors,
         ChannelReader<MqttMessage> messageReader, ChannelWriter<MqttPacket> packetWriter, ILoggingAdapter log,
         MqttClientConnectOptions options, Task<DisconnectReasonCode> trueDeath)
@@ -170,17 +175,17 @@ public sealed class MqttClient : IInternalMqttClient
 
     /// <summary>
     /// Used to swap out the transport for a new one during reconnect scenarios.
+    /// Thread-safe via <see cref="Interlocked.Exchange{T}"/>.
     /// </summary>
     /// <param name="newTransport">The replacement transport</param>
     void IInternalMqttClient.SwapTransport(IMqttTransport newTransport)
     {
-        _transport = newTransport;
-        var a = _transport;
+        Interlocked.Exchange(ref _transport, newTransport);
     }
 
     public MqttProtocolVersion ProtocolVersion => _options.ProtocolVersion;
     public string ClientId => _options.ClientId;
-    public bool IsConnected => _transport.Status == ConnectionStatus.Connected;
+    public bool IsConnected => Transport.Status == ConnectionStatus.Connected;
 
     public async Task AbortConnectionAsync()
     {
@@ -191,14 +196,15 @@ public sealed class MqttClient : IInternalMqttClient
 
     public async Task<IConnectResponse> ConnectAsync(CancellationToken cancellationToken = default)
     {
-        if (_transport.Status == ConnectionStatus.Connected)
+        var transport = Transport;
+        if (transport.Status == ConnectionStatus.Connected)
             return new AckProtocol.ConnectSuccess("Already connected to broker.");
-        if(!(_transport.Status == ConnectionStatus.Connecting ||
-           _transport.Status == ConnectionStatus.NotStarted))
-                return new AckProtocol.ConnectFailure($"Already in state [{_transport.Status}]");
+        if(!(transport.Status == ConnectionStatus.Connecting ||
+           transport.Status == ConnectionStatus.NotStarted))
+                return new AckProtocol.ConnectFailure($"Already in state [{transport.Status}]");
 
         // this will blow up if there's a problem with the connection
-        var connectionResult = await _transport.ConnectAsync(cancellationToken);
+        var connectionResult = await transport.ConnectAsync(cancellationToken);
         
         if (!connectionResult)
         {
@@ -278,6 +284,11 @@ public sealed class MqttClient : IInternalMqttClient
 
             return resp;
         }
+        catch (OperationCanceledException)
+        {
+            // Cancellation — let the caller handle lifecycle (e.g., reconnect flow)
+            return new AckProtocol.ConnectFailure("Connection attempt was cancelled.");
+        }
         catch (Exception ex)
         {
             _log.Error(ex, "Failed to connect to MQTT broker - Reason: {0}", ex.Message);
@@ -291,7 +302,7 @@ public sealed class MqttClient : IInternalMqttClient
     public async Task DisconnectAsync(CancellationToken cancellationToken = default)
     {
         // already disconnected
-        if (_transport.Status is ConnectionStatus.Disconnected or ConnectionStatus.Aborted or ConnectionStatus.NotStarted)
+        if (Transport.Status is ConnectionStatus.Disconnected or ConnectionStatus.Aborted or ConnectionStatus.NotStarted)
             return;
 
         var disconnectPacket = new DisconnectPacket();
@@ -333,9 +344,6 @@ public sealed class MqttClient : IInternalMqttClient
     public async Task<IPublishResult> PublishAsync(MqttMessage message,
         CancellationToken cancellationToken = default)
     {
-        if (_transport.Status != ConnectionStatus.Connected)
-            return new PublishingProtocol.PublishFailure("Not connected to broker.");
-
         var publishPacket = message.ToPacket();
 
         Task<IPublishResult> WaitForAck(IActorRef targetActor, PublishPacket packet)
@@ -430,7 +438,7 @@ public sealed class MqttClient : IInternalMqttClient
     public async Task<ISubscribeResponse> SubscribeAsync(TopicSubscription[] topics,
         CancellationToken cancellationToken = default)
     {
-        if (_transport.Status != ConnectionStatus.Connected)
+        if (Transport.Status != ConnectionStatus.Connected)
             return new AckProtocol.SubscribeFailure("Not connected to broker.");
 
         var subscribePacket = new SubscribePacket()
@@ -476,7 +484,7 @@ public sealed class MqttClient : IInternalMqttClient
 
     public async Task<IUnsubscribeResponse> UnsubscribeAsync(string[] topics, CancellationToken cancellationToken = default)
     {
-        if (_transport.Status != ConnectionStatus.Connected)
+        if (Transport.Status != ConnectionStatus.Connected)
             return new AckProtocol.UnsubscribeFailure("Not connected to broker.");
 
         var unsubscribePacket = new UnsubscribePacket()
@@ -516,7 +524,7 @@ public sealed class MqttClient : IInternalMqttClient
 
     public async ValueTask DisposeAsync()
     {
-        if (_transport.Status is not (ConnectionStatus.Aborted or ConnectionStatus.Disconnected))
+        if (Transport.Status is not (ConnectionStatus.Aborted or ConnectionStatus.Disconnected))
             await AbortConnectionAsync();
     }
 }

--- a/src/TurboMqtt/Client/IMqttClient.cs
+++ b/src/TurboMqtt/Client/IMqttClient.cs
@@ -147,6 +147,8 @@ internal interface IInternalMqttClient : IMqttClient
 public sealed class MqttClient : IInternalMqttClient
 {
     private readonly MqttClientConnectOptions _options;
+    // All reads must go through the Transport property (Volatile.Read);
+    // writes use Interlocked.Exchange in SwapTransport.
     private IMqttTransport _transport;
     private readonly IActorRef _clientOwner;
     private readonly MqttRequiredActors _requiredActors;
@@ -276,9 +278,7 @@ public sealed class MqttClient : IInternalMqttClient
             if (!resp.IsSuccess)
             {
                 _log.Error("Failed to connect to MQTT broker - Reason: {0}", resp.Reason);
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                AbortConnectionAsync();
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                _ = AbortConnectionAsync();
                 return resp;
             }
 
@@ -292,9 +292,7 @@ public sealed class MqttClient : IInternalMqttClient
         catch (Exception ex)
         {
             _log.Error(ex, "Failed to connect to MQTT broker - Reason: {0}", ex.Message);
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-            AbortConnectionAsync();
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            _ = AbortConnectionAsync();
             return new AckProtocol.ConnectFailure(ex.Message);
         }
     }

--- a/src/TurboMqtt/Client/IMqttClientFactory.cs
+++ b/src/TurboMqtt/Client/IMqttClientFactory.cs
@@ -23,6 +23,15 @@ public interface IMqttClientFactory
     /// <param name="tcpOptions">Options for controlling our TCP socket.</param>
     /// <returns></returns>
     Task<IMqttClient> CreateTcpClient(MqttClientConnectOptions options, MqttClientTcpOptions tcpOptions);
+
+    /// <summary>
+    /// Creates a TLS-secured TCP-based MQTT client.
+    /// </summary>
+    /// <param name="options">Options for our <see cref="ConnectPacket"/> to the broker.</param>
+    /// <param name="tcpOptions">Options for controlling our TCP socket.</param>
+    /// <param name="tlsOptions">TLS/SSL options for securing the connection.</param>
+    Task<IMqttClient> CreateTlsTcpClient(MqttClientConnectOptions options, MqttClientTcpOptions tcpOptions,
+        MqttClientTlsOptions tlsOptions);
 }
 
 /// <summary>
@@ -63,6 +72,24 @@ public sealed class MqttClientFactory : IMqttClientFactory, IInternalMqttClientF
         var client = await clientActor.Ask<IMqttClient>(new ClientStreamOwner.CreateClient(transportManager, options))
             .ConfigureAwait(false);
         
+        return client;
+    }
+
+    public async Task<IMqttClient> CreateTlsTcpClient(MqttClientConnectOptions options, MqttClientTcpOptions tcpOptions,
+        MqttClientTlsOptions tlsOptions)
+    {
+        AssertMqtt311(options);
+        var streamProvider = new TlsStreamProvider(tcpOptions, tlsOptions);
+        var transportManager = new TcpMqttTransportManager(tcpOptions, _mqttClientManager, options.ProtocolVersion,
+            streamProvider);
+
+        var clientActor =
+            await _mqttClientManager.Ask<IActorRef>(new ClientManagerActor.StartClientActor(options.ClientId))
+                .ConfigureAwait(false);
+
+        var client = await clientActor.Ask<IMqttClient>(new ClientStreamOwner.CreateClient(transportManager, options))
+            .ConfigureAwait(false);
+
         return client;
     }
 

--- a/src/TurboMqtt/Client/MqttClientTcpOptions.cs
+++ b/src/TurboMqtt/Client/MqttClientTcpOptions.cs
@@ -35,6 +35,12 @@ public sealed record MqttClientTcpOptions
     public int Port { get; }
     
     /// <summary>
+    /// Maximum time to wait for the TCP connection to be established before aborting.
+    /// Applied in addition to any caller-supplied <see cref="CancellationToken"/>.
+    /// </summary>
+    public TimeSpan ConnectTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
     /// How long should we wait before attempting to reconnect the client?
     /// </summary>
     public TimeSpan ReconnectInterval { get; set; } = TimeSpan.FromSeconds(5);

--- a/src/TurboMqtt/Client/MqttClientTlsOptions.cs
+++ b/src/TurboMqtt/Client/MqttClientTlsOptions.cs
@@ -1,0 +1,39 @@
+// -----------------------------------------------------------------------
+// <copyright file="MqttClientTlsOptions.cs" company="Petabridge, LLC">
+//      Copyright (C) 2024 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+namespace TurboMqtt.Client;
+
+/// <summary>
+/// TLS/SSL options for securing MQTT client connections.
+/// </summary>
+public sealed record MqttClientTlsOptions
+{
+    /// <summary>
+    /// Client certificates for mutual TLS authentication.
+    /// </summary>
+    public X509CertificateCollection? ClientCertificates { get; init; }
+
+    /// <summary>
+    /// Custom server certificate validation callback.
+    /// When null, uses default system validation.
+    /// </summary>
+    public RemoteCertificateValidationCallback? ServerCertificateValidationCallback { get; init; }
+
+    /// <summary>
+    /// The TLS/SSL protocols to use. Defaults to <see cref="SslProtocols.None"/> (system default, typically TLS 1.2+).
+    /// </summary>
+    public SslProtocols EnabledSslProtocols { get; init; } = SslProtocols.None;
+
+    /// <summary>
+    /// Target host name for TLS SNI (Server Name Indication).
+    /// When null, defaults to <see cref="MqttClientTcpOptions.Host"/>.
+    /// </summary>
+    public string? TargetHost { get; init; }
+}

--- a/src/TurboMqtt/IO/MqttTransport.cs
+++ b/src/TurboMqtt/IO/MqttTransport.cs
@@ -104,6 +104,8 @@ public enum ConnectionStatus
     NotStarted,
     Connecting,
     Connected,
+    Draining,
+    Closing,
     Disconnected,
     Aborted,
     Failed

--- a/src/TurboMqtt/IO/Tcp/IStreamProvider.cs
+++ b/src/TurboMqtt/IO/Tcp/IStreamProvider.cs
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------
+// <copyright file="IStreamProvider.cs" company="Petabridge, LLC">
+//      Copyright (C) 2024 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace TurboMqtt.IO.Tcp;
+
+/// <summary>
+/// Abstraction over the network stream creation process.
+/// Implementations create a connected <see cref="Stream"/> from connection parameters,
+/// enabling TCP, TLS, and test stream providers to be swapped transparently.
+/// </summary>
+internal interface IStreamProvider
+{
+    /// <summary>
+    /// Creates a connected <see cref="Stream"/> to the specified host and port.
+    /// </summary>
+    /// <param name="host">The hostname to connect to.</param>
+    /// <param name="port">The port number.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A connected <see cref="Stream"/> ready for reading and writing.</returns>
+    Task<Stream> ConnectAsync(string host, int port, CancellationToken ct = default);
+
+    /// <summary>
+    /// Closes and cleans up the underlying connection resources (socket, etc.).
+    /// </summary>
+    void Close();
+}

--- a/src/TurboMqtt/IO/Tcp/TcpConnectionManager.cs
+++ b/src/TurboMqtt/IO/Tcp/TcpConnectionManager.cs
@@ -18,8 +18,9 @@ internal sealed class TcpConnectionManager : UntypedActor
 {
     public sealed record CreateTcpTransport(
         MqttClientTcpOptions Options,
-        MqttProtocolVersion ProtocolVersion);
-    
+        MqttProtocolVersion ProtocolVersion,
+        IStreamProvider? StreamProvider = null);
+
     private readonly ILoggingAdapter _log = Context.GetLogger();
 
     protected override void OnReceive(object message)
@@ -29,7 +30,8 @@ internal sealed class TcpConnectionManager : UntypedActor
             case CreateTcpTransport create:
             {
                 _log.Debug("Creating new TCP transport for [{0}]", create);
-                var tcpTransport = Context.ActorOf(Props.Create(() => new TcpTransportActor(create.Options)));
+                var streamProvider = create.StreamProvider ?? new TcpStreamProvider(create.Options);
+                var tcpTransport = Context.ActorOf(Props.Create(() => new TcpTransportActor(create.Options, streamProvider)));
                 Sender.Tell(tcpTransport);
                 break;
             }

--- a/src/TurboMqtt/IO/Tcp/TcpStreamProvider.cs
+++ b/src/TurboMqtt/IO/Tcp/TcpStreamProvider.cs
@@ -1,0 +1,87 @@
+// -----------------------------------------------------------------------
+// <copyright file="TcpStreamProvider.cs" company="Petabridge, LLC">
+//      Copyright (C) 2024 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net;
+using System.Net.Sockets;
+using TurboMqtt.Client;
+
+namespace TurboMqtt.IO.Tcp;
+
+/// <summary>
+/// Creates a plain TCP connection and returns a <see cref="NetworkStream"/>.
+/// </summary>
+internal sealed class TcpStreamProvider : IStreamProvider
+{
+    private readonly AddressFamily _addressFamily;
+    private readonly int _maxFrameSize;
+    private Socket? _socket;
+
+    public TcpStreamProvider(AddressFamily addressFamily, int maxFrameSize)
+    {
+        _addressFamily = addressFamily;
+        _maxFrameSize = maxFrameSize;
+    }
+
+    public TcpStreamProvider(MqttClientTcpOptions tcpOptions)
+        : this(tcpOptions.AddressFamily, tcpOptions.MaxFrameSize)
+    {
+    }
+
+    public async Task<Stream> ConnectAsync(string host, int port, CancellationToken ct = default)
+    {
+        _socket = CreateSocket();
+
+        var addresses = await Dns.GetHostAddressesAsync(host, ct).ConfigureAwait(false);
+        if (addresses.Length == 0)
+            throw new ArgumentException($"Could not resolve any IP addresses for host '{host}'.", nameof(host));
+
+        await _socket.ConnectAsync(addresses, port, ct).ConfigureAwait(false);
+
+        return new NetworkStream(_socket, ownsSocket: false);
+    }
+
+    public void Close()
+    {
+        if (_socket is null)
+            return;
+
+        try
+        {
+            _socket.Close();
+            _socket.Dispose();
+        }
+        catch (ObjectDisposedException)
+        {
+            // already disposed
+        }
+        finally
+        {
+            _socket = null;
+        }
+    }
+
+    private Socket CreateSocket()
+    {
+        var bufferSize = TcpTransportActor.ScaleBufferSize(_maxFrameSize);
+
+        if (_addressFamily == AddressFamily.Unspecified)
+            return new Socket(SocketType.Stream, ProtocolType.Tcp)
+            {
+                NoDelay = true,
+                LingerState = new LingerOption(true, 2),
+                ReceiveBufferSize = bufferSize,
+                SendBufferSize = bufferSize
+            };
+
+        return new Socket(_addressFamily, SocketType.Stream, ProtocolType.Tcp)
+        {
+            NoDelay = true,
+            LingerState = new LingerOption(true, 2),
+            ReceiveBufferSize = bufferSize,
+            SendBufferSize = bufferSize
+        };
+    }
+}

--- a/src/TurboMqtt/IO/Tcp/TcpTransport.cs
+++ b/src/TurboMqtt/IO/Tcp/TcpTransport.cs
@@ -22,18 +22,21 @@ internal sealed class TcpMqttTransportManager : IMqttTransportManager
     private readonly MqttClientTcpOptions _tcpOptions;
     private readonly MqttProtocolVersion _protocolVersion;
     private readonly IActorRef _mqttClientManager;
+    private readonly IStreamProvider? _streamProvider;
 
-    public TcpMqttTransportManager(MqttClientTcpOptions tcpOptions, IActorRef mqttClientManager, MqttProtocolVersion protocolVersion)
+    public TcpMqttTransportManager(MqttClientTcpOptions tcpOptions, IActorRef mqttClientManager, MqttProtocolVersion protocolVersion,
+        IStreamProvider? streamProvider = null)
     {
         _tcpOptions = tcpOptions;
         _mqttClientManager = mqttClientManager;
         _protocolVersion = protocolVersion;
+        _streamProvider = streamProvider;
     }
 
     public async Task<IMqttTransport> CreateTransportAsync(CancellationToken ct = default)
     {
         var tcpTransportActor =
-            await _mqttClientManager.Ask<IActorRef>(new TcpConnectionManager.CreateTcpTransport(_tcpOptions, _protocolVersion), cancellationToken: ct)
+            await _mqttClientManager.Ask<IActorRef>(new TcpConnectionManager.CreateTcpTransport(_tcpOptions, _protocolVersion, _streamProvider), cancellationToken: ct)
                 .ConfigureAwait(false);
 
         // get the TCP transport

--- a/src/TurboMqtt/IO/Tcp/TcpTransportActor.cs
+++ b/src/TurboMqtt/IO/Tcp/TcpTransportActor.cs
@@ -6,15 +6,12 @@
 
 using System.Buffers;
 using System.IO.Pipelines;
-using System.Net;
-using System.Net.Sockets;
 using System.Threading.Channels;
 using Akka.Actor;
 using Akka.Event;
 using TurboMqtt.Client;
 using TurboMqtt.PacketTypes;
 using TurboMqtt.Protocol;
-using Debug = System.Diagnostics.Debug;
 
 namespace TurboMqtt.IO.Tcp;
 
@@ -43,15 +40,15 @@ internal sealed class TcpTransportActor : UntypedActor
             MaxFrameSize = maxFrameSize;
             WaitForPendingWrites = waitForPendingWrites;
         }
-        
+
         private int _status = (int)ConnectionStatus.NotStarted;
 
-        public ConnectionStatus Status 
-        { 
+        public ConnectionStatus Status
+        {
             get => (ConnectionStatus)Volatile.Read(ref _status);
             set => Volatile.Write(ref _status, (int)value);
         }
-        
+
         /// <summary>
         /// Atomically update the status if current value matches expected.
         /// </summary>
@@ -121,7 +118,8 @@ internal sealed class TcpTransportActor : UntypedActor
 
     public ConnectionState State { get; private set; }
 
-    private Socket? _tcpClient;
+    private readonly IStreamProvider _streamProvider;
+    private Stream? _stream;
 
     private readonly Channel<(IMemoryOwner<byte> buffer, int readableBytes)> _writesToTransport =
         Channel.CreateUnbounded<(IMemoryOwner<byte> buffer, int readableBytes)>();
@@ -133,14 +131,15 @@ internal sealed class TcpTransportActor : UntypedActor
     private readonly ILoggingAdapter _log = Context.GetLogger();
 
     private readonly Pipe _pipe;
-    
+
     // Track task completion for graceful shutdown
     private readonly TaskCompletionSource _shutdownComplete = new();
 
-    public TcpTransportActor(MqttClientTcpOptions tcpOptions)
+    public TcpTransportActor(MqttClientTcpOptions tcpOptions, IStreamProvider streamProvider)
     {
         TcpOptions = tcpOptions;
         MaxFrameSize = tcpOptions.MaxFrameSize;
+        _streamProvider = streamProvider;
 
         State = new ConnectionState(_writesToTransport.Writer, _readsFromTransport.Reader, _whenTerminated.Task,
             MaxFrameSize, _writesToTransport.Reader.Completion); // we signal completion when _writesToTransport is done
@@ -153,9 +152,9 @@ internal sealed class TcpTransportActor : UntypedActor
      * FSM:
      * OnReceive (nothing has happened) --> CreateTcpTransport --> TransportCreated BECOME Connecting
      * Connecting --> DoConnect --> Connecting (already connecting) --> ConnectResult (Connected) BECOME Running
-     * Running --> DoWriteToPipeAsync --> Running (read data from socket) --> DoWriteToSocketAsync --> Running (write data to socket)
+     * Running --> DoWriteToPipeAsync --> Running (read data from stream) --> DoWriteToSocketAsync --> Running (write data to stream)
      */
-    
+
     /// <summary>
     /// Performs the max buffer size scaling for the socket.
     /// </summary>
@@ -165,11 +164,11 @@ internal sealed class TcpTransportActor : UntypedActor
         // if the max frame size is under 128kb, scale it up to 512kb
         if (maxFrameSize <= 128 * 1024)
             return 512 * 1024;
-        
+
         // between 128kb and 1mb, scale it up to 2mb
         if (maxFrameSize <= 1024 * 1024)
             return 2 * 1024 * 1024;
-        
+
         // if the max frame size is above 1mb, 2x it
         return maxFrameSize * 2;
     }
@@ -180,9 +179,6 @@ internal sealed class TcpTransportActor : UntypedActor
         {
             case CreateTcpTransport when State.Status == ConnectionStatus.NotStarted:
             {
-                // first things first - attempt to create the socket
-                CreateTcpClient();
-
                 // return the transport to the client
                 var tcpTransport = new TcpTransport(_log, State, Self);
                 Sender.Tell(tcpTransport);
@@ -202,50 +198,6 @@ internal sealed class TcpTransportActor : UntypedActor
         }
     }
 
-    private void CreateTcpClient()
-    {
-        if (TcpOptions.AddressFamily == AddressFamily.Unspecified)
-            _tcpClient = new Socket(SocketType.Stream, ProtocolType.Tcp)
-            {
-                NoDelay = true,
-                LingerState = new LingerOption(true, 2), // give us a little time to flush the socket
-                ReceiveBufferSize = ScaleBufferSize(TcpOptions.MaxFrameSize),
-                SendBufferSize = ScaleBufferSize(TcpOptions.MaxFrameSize)
-            };
-        else
-            _tcpClient = new Socket(TcpOptions.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
-            {
-                ReceiveBufferSize = ScaleBufferSize(TcpOptions.MaxFrameSize),
-                SendBufferSize = ScaleBufferSize(TcpOptions.MaxFrameSize),
-                NoDelay = true,
-                LingerState = new LingerOption(true, 2) // give us a little time to flush the socket
-            };
-    }
-
-    private async Task DoConnectAsync(IPAddress[] addresses, int port, IActorRef destination,
-        CancellationToken ct = default)
-    {
-        ConnectResult connectResult;
-        try
-        {
-            if (addresses.Length == 0)
-                throw new ArgumentException("No IP addresses provided to connect to.", nameof(addresses));
-
-            Debug.Assert(_tcpClient != null, nameof(_tcpClient) + " != null");
-            await _tcpClient.ConnectAsync(addresses, port, ct).ConfigureAwait(false);
-            connectResult = new ConnectResult(ConnectionStatus.Connected, "Connected.");
-        }
-        catch (Exception ex)
-        {
-            _log.Error(ex, "Failed to connect to [{0}:{1}]", TcpOptions.Host, TcpOptions.Port);
-            connectResult = new ConnectResult(ConnectionStatus.Failed, ex.Message);
-        }
-
-        // let both parties know the result of the connection attempt
-        destination.Tell(connectResult);
-        _closureSelf.Tell(connectResult);
-    }
-
     private readonly IActorRef _closureSelf = Context.Self;
 
     private void TransportCreated(object message)
@@ -259,27 +211,27 @@ internal sealed class TcpTransportActor : UntypedActor
                     _log.Info("Attempting to connect to [{0}:{1}]", TcpOptions.Host, TcpOptions.Port);
 
                     var sender = Sender;
-                    
+
                     // set status to connecting
                     State.Status = ConnectionStatus.Connecting;
 
-                    await ResolveAndConnect(connect.Cancel);
-                    return;
-
-                    // need to resolve DNS to an IP address
-                    async Task ResolveAndConnect(CancellationToken ct)
+                    ConnectResult connectResult;
+                    try
                     {
-                        var resolved = await Dns.GetHostAddressesAsync(TcpOptions.Host, ct).ConfigureAwait(false);
-
-                        if (_log.IsDebugEnabled)
-                            _log.Debug("Attempting to connect to [{0}:{1}] - resolved to [{2}]", TcpOptions.Host,
-                                TcpOptions.Port,
-                                string.Join(", ", resolved.Select(c => c.ToString())));
-
-                        await DoConnectAsync(resolved, TcpOptions.Port, sender, ct).ConfigureAwait(false);
+                        _stream = await _streamProvider.ConnectAsync(TcpOptions.Host, TcpOptions.Port, connect.Cancel)
+                            .ConfigureAwait(false);
+                        connectResult = new ConnectResult(ConnectionStatus.Connected, "Connected.");
                     }
+                    catch (Exception ex)
+                    {
+                        _log.Error(ex, "Failed to connect to [{0}:{1}]", TcpOptions.Host, TcpOptions.Port);
+                        connectResult = new ConnectResult(ConnectionStatus.Failed, ex.Message);
+                    }
+
+                    sender.Tell(connectResult);
+                    _closureSelf.Tell(connectResult);
                 });
-                
+
                 break;
             }
             case DoConnect:
@@ -337,19 +289,11 @@ internal sealed class TcpTransportActor : UntypedActor
                     try
                     {
                         var workingBuffer = buffer.Memory;
-                        while (readableBytes > 0 && _tcpClient is { Connected: true })
+                        while (readableBytes > 0 && _stream is not null)
                         {
-                            var sent = await _tcpClient!.SendAsync(workingBuffer.Slice(0, readableBytes), ct)
-                                .ConfigureAwait(false);
-                            if (sent == 0)
-                            {
-                                _log.Warning("Failed to write to socket - no bytes written.");
-                                _closureSelf.Tell(ReadFinished.Instance);
-                                goto WritesFinished;
-                            }
-
-                            readableBytes -= sent;
-                            workingBuffer = workingBuffer.Slice(sent);
+                            var slice = workingBuffer.Slice(0, readableBytes);
+                            await _stream!.WriteAsync(slice, ct).ConfigureAwait(false);
+                            readableBytes = 0; // Stream.WriteAsync writes all bytes
                         }
                     }
                     finally
@@ -389,7 +333,7 @@ internal sealed class TcpTransportActor : UntypedActor
             var memory = _pipe.Writer.GetMemory(TcpOptions.MaxFrameSize / 4);
             try
             {
-                int bytesRead = await _tcpClient!.ReceiveAsync(memory, SocketFlags.None, ct);
+                int bytesRead = await _stream!.ReadAsync(memory, ct).ConfigureAwait(false);
                 if (bytesRead == 0)
                 {
                     // we are done reading - socket was gracefully closed
@@ -405,6 +349,7 @@ internal sealed class TcpTransportActor : UntypedActor
             {
                 // no need to log here
                 _closureSelf.Tell(ReadFinished.Instance);
+                return;
             }
             catch (Exception ex)
             {
@@ -439,13 +384,11 @@ internal sealed class TcpTransportActor : UntypedActor
                 var result = await _pipe.Reader.ReadAsync(ct);
                 var buffer = result.Buffer;
 
-                // consume this entire sequence by copying it into a new buffer
-                // have to copy because there's no guarantee we can safely release a shared buffer
-                // once we hand the message over to the end-user.
-                var newMemory = new Memory<byte>(new byte[buffer.Length]);
-                var unshared = new UnsharedMemoryOwner<byte>(newMemory);
-                buffer.CopyTo(newMemory.Span);
-                _readsFromTransport.Writer.TryWrite((unshared, newMemory.Length));
+                // consume this entire sequence by copying it into a pooled buffer
+                var length = (int)buffer.Length;
+                var pooled = MemoryPool<byte>.Shared.Rent(length);
+                buffer.CopyTo(pooled.Memory.Span);
+                _readsFromTransport.Writer.TryWrite((pooled, length));
 
                 // tell the pipe we're done with this data
                 _pipe.Reader.AdvanceTo(buffer.End);
@@ -459,6 +402,7 @@ internal sealed class TcpTransportActor : UntypedActor
             catch (OperationCanceledException)
             {
                 _closureSelf.Tell(ReadFinished.Instance);
+                return;
             }
         }
     }
@@ -494,7 +438,7 @@ internal sealed class TcpTransportActor : UntypedActor
         _readsFromTransport.Writer.TryWrite(DisconnectToBinary.NormalDisconnectPacket.ToBinary(MqttProtocolVersion.V3_1_1));
 
         State.Status = ConnectionStatus.Disconnected;
-        
+
         // no more writes to transport
         _writesToTransport.Writer.TryComplete();
 
@@ -510,7 +454,7 @@ internal sealed class TcpTransportActor : UntypedActor
         {
             _readsFromTransport.Writer.TryComplete();
         }
-        
+
         // Cancel the background tasks gracefully
         try
         {
@@ -520,31 +464,30 @@ internal sealed class TcpTransportActor : UntypedActor
         {
             // Already cancelled, ignore
         }
-        
+
         // Brief delay to allow ongoing operations to complete
         await Task.Delay(100);
 
         _closureSelf.Tell(PoisonPill.Instance);
     }
 
-    private void DisposeSocket(ConnectionStatus newStatus)
+    private void DisposeStreamProvider(ConnectionStatus newStatus)
     {
-        _log.Info("Disposing of TCP client socket.");
-        if (_tcpClient is null)
-            return; // already disposed
+        _log.Info("Disposing of TCP transport stream.");
 
         try
         {
             State.Status = newStatus;
-
 
             // stop reading from the socket
             State.ShutDownCts.Cancel();
 
             _pipe.Reader.Complete();
             _pipe.Writer.Complete();
-            _tcpClient?.Close();
-            _tcpClient?.Dispose();
+
+            _stream?.Close();
+            _stream?.Dispose();
+            _streamProvider.Close();
         }
         catch (Exception ex)
         {
@@ -552,7 +495,7 @@ internal sealed class TcpTransportActor : UntypedActor
         }
         finally
         {
-            _tcpClient = null;
+            _stream = null;
         }
     }
 
@@ -573,7 +516,7 @@ internal sealed class TcpTransportActor : UntypedActor
             _ => ConnectionStatus.Aborted
         };
 
-        DisposeSocket(newStatus);
+        DisposeStreamProvider(newStatus);
 
         // let upstairs know we're done
         _whenTerminated.TrySetResult(reason);

--- a/src/TurboMqtt/IO/Tcp/TcpTransportActor.cs
+++ b/src/TurboMqtt/IO/Tcp/TcpTransportActor.cs
@@ -52,15 +52,6 @@ internal sealed class TcpTransportActor : UntypedActor
             internal set => Volatile.Write(ref _status, (int)value);
         }
 
-        /// <summary>
-        /// Atomically update the status if current value matches expected.
-        /// </summary>
-        /// <returns>True if the update was successful, false otherwise.</returns>
-        public bool CompareAndSetStatus(ConnectionStatus expected, ConnectionStatus newValue)
-        {
-            return Interlocked.CompareExchange(ref _status, (int)newValue, (int)expected) == (int)expected;
-        }
-
         public CancellationTokenSource ShutDownCts { get; } = new();
 
         public int MaxFrameSize { get; }

--- a/src/TurboMqtt/IO/Tcp/TcpTransportActor.cs
+++ b/src/TurboMqtt/IO/Tcp/TcpTransportActor.cs
@@ -17,6 +17,11 @@ namespace TurboMqtt.IO.Tcp;
 
 /// <summary>
 /// Actor responsible for managing the TCP transport layer for MQTT.
+///
+/// FSM:
+///   NotStarted (OnReceive) → Created (TransportCreated) → Connecting (via RunTask)
+///   → Connected → Draining → Closing → Stopped
+///                  Connected → Aborted → Stopped
 /// </summary>
 internal sealed class TcpTransportActor : UntypedActor
 {
@@ -111,6 +116,30 @@ internal sealed class TcpTransportActor : UntypedActor
     /// <param name="ReasonMessage"></param>
     public sealed record ConnectionUnexpectedlyClosed(DisconnectReasonCode Reason, string ReasonMessage);
 
+    /// <summary>
+    /// Self-tell sent when all three background tasks (read-from-stream, read-from-pipe, write-to-stream) have completed.
+    /// </summary>
+    private sealed class BackgroundTasksCompleted : IDeadLetterSuppression
+    {
+        private BackgroundTasksCompleted()
+        {
+        }
+
+        public static BackgroundTasksCompleted Instance { get; } = new();
+    }
+
+    /// <summary>
+    /// Self-tell sent when outbound data has been flushed during the Draining state.
+    /// </summary>
+    private sealed class OutboundFlushed : IDeadLetterSuppression
+    {
+        private OutboundFlushed()
+        {
+        }
+
+        public static OutboundFlushed Instance { get; } = new();
+    }
+
     #endregion
 
     public MqttClientTcpOptions TcpOptions { get; }
@@ -132,8 +161,11 @@ internal sealed class TcpTransportActor : UntypedActor
 
     private readonly Pipe _pipe;
 
-    // Track task completion for graceful shutdown
-    private readonly TaskCompletionSource _shutdownComplete = new();
+    // Guard against multiple PoisonPill sends
+    private bool _poisonPillSent;
+
+    // Guard against CTS double-cancel
+    private int _ctsCancelled;
 
     public TcpTransportActor(MqttClientTcpOptions tcpOptions, IStreamProvider streamProvider)
     {
@@ -147,13 +179,6 @@ internal sealed class TcpTransportActor : UntypedActor
         _pipe = new Pipe(new PipeOptions(pauseWriterThreshold: ScaleBufferSize(MaxFrameSize), resumeWriterThreshold: ScaleBufferSize(MaxFrameSize) / 2,
             useSynchronizationContext: false));
     }
-
-    /*
-     * FSM:
-     * OnReceive (nothing has happened) --> CreateTcpTransport --> TransportCreated BECOME Connecting
-     * Connecting --> DoConnect --> Connecting (already connecting) --> ConnectResult (Connected) BECOME Running
-     * Running --> DoWriteToPipeAsync --> Running (read data from stream) --> DoWriteToSocketAsync --> Running (write data to stream)
-     */
 
     /// <summary>
     /// Performs the max buffer size scaling for the socket.
@@ -249,7 +274,7 @@ internal sealed class TcpTransportActor : UntypedActor
                 _log.Info("Successfully connected to [{0}:{1}]", TcpOptions.Host, TcpOptions.Port);
                 State.Status = ConnectionStatus.Connected;
 
-                BecomeRunning();
+                BecomeConnected();
                 break;
             }
             case ConnectResult { Status: ConnectionStatus.Failed }:
@@ -265,15 +290,22 @@ internal sealed class TcpTransportActor : UntypedActor
         }
     }
 
-    private void BecomeRunning()
+    /// <summary>
+    /// Transitions to the Connected state and starts the three background tasks,
+    /// tracking them with Task.WhenAll + ContinueWith self-tell.
+    /// </summary>
+    private void BecomeConnected()
     {
-        Become(Running);
+        Become(Connected);
 
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-        DoWriteToPipeAsync(State.ShutDownCts.Token);
-        ReadFromPipeAsync(State.ShutDownCts.Token);
-        DoWriteToSocketAsync(State.ShutDownCts.Token);
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+        var readFromStreamTask = DoWriteToPipeAsync(State.ShutDownCts.Token);
+        var readFromPipeTask = ReadFromPipeAsync(State.ShutDownCts.Token);
+        var writeToStreamTask = DoWriteToSocketAsync(State.ShutDownCts.Token);
+
+        Task.WhenAll(readFromStreamTask, readFromPipeTask, writeToStreamTask).ContinueWith(_ =>
+        {
+            _closureSelf.Tell(BackgroundTasksCompleted.Instance);
+        }, TaskContinuationOptions.ExecuteSynchronously);
     }
 
     private async Task DoWriteToSocketAsync(CancellationToken ct)
@@ -307,23 +339,20 @@ internal sealed class TcpTransportActor : UntypedActor
             {
                 // we're being shut down
                 _log.Debug("Shutting down write to socket.");
-                _closureSelf.Tell(ReadFinished.Instance);
-                goto WritesFinished;
+                return;
             }
             catch (Exception ex)
             {
                 _log.Error(ex, "Failed to write to socket.");
                 // we are done writing
                 _closureSelf.Tell(new ConnectionUnexpectedlyClosed(DisconnectReasonCode.UnspecifiedError, ex.Message));
-                // socket was closed
                 // abort ongoing reads and writes, but don't shutdown the transport
-                await State.ShutDownCts.CancelAsync();
-                goto WritesFinished;
+                TryCancelCts();
+                return;
             }
         }
 
-        WritesFinished:
-            _writesToTransport.Writer.TryComplete(); // can't write anymore either
+        _writesToTransport.Writer.TryComplete(); // can't write anymore either
     }
 
     private async Task DoWriteToPipeAsync(CancellationToken ct)
@@ -338,8 +367,6 @@ internal sealed class TcpTransportActor : UntypedActor
                 {
                     // we are done reading - socket was gracefully closed
                     _closureSelf.Tell(ReadFinished.Instance);
-                    // abort ongoing reads and writes, but don't shutdown the transport
-                    await State.ShutDownCts.CancelAsync();
                     return;
                 }
 
@@ -348,7 +375,6 @@ internal sealed class TcpTransportActor : UntypedActor
             catch (OperationCanceledException)
             {
                 // no need to log here
-                _closureSelf.Tell(ReadFinished.Instance);
                 return;
             }
             catch (Exception ex)
@@ -357,9 +383,6 @@ internal sealed class TcpTransportActor : UntypedActor
                 _log.Debug(ex, "Failed to read from socket.");
                 // we are done reading
                 _closureSelf.Tell(new ConnectionUnexpectedlyClosed(DisconnectReasonCode.UnspecifiedError, ex.Message));
-                // socket was closed
-                // abort ongoing reads and writes, but don't shutdown the transport
-                await State.ShutDownCts.CancelAsync();
                 return;
             }
 
@@ -367,7 +390,6 @@ internal sealed class TcpTransportActor : UntypedActor
             var result = await _pipe.Writer.FlushAsync(ct);
             if (result.IsCompleted)
             {
-                _closureSelf.Tell(ReadFinished.Instance);
                 return;
             }
         }
@@ -407,68 +429,204 @@ internal sealed class TcpTransportActor : UntypedActor
         }
     }
 
-    private void Running(object message)
+    /// <summary>
+    /// Connected state — the transport is active and reading/writing data.
+    /// Valid transitions: DoClose → Draining, ReadFinished → Closing, ConnectionUnexpectedlyClosed → Aborted
+    /// </summary>
+    private void Connected(object message)
     {
         switch (message)
         {
-            case DoClose: // we are closing
+            case DoClose:
             {
-                _ = CleanUpGracefully(true);
+                _log.Debug("Received DoClose in Connected state. Transitioning to Draining.");
+                BecomeDraining();
                 break;
             }
-            case ReadFinished: // server closed us
+            case ReadFinished:
             {
-                _ = CleanUpGracefully(true); // idempotent
+                _log.Debug("Received ReadFinished in Connected state. Transitioning to Closing.");
+                BecomeClosing();
                 break;
             }
             case ConnectionUnexpectedlyClosed closed:
             {
-                // we got aborted
                 _log.Warning("Connection to [{0}:{1}] was unexpectedly closed: {2}", TcpOptions.Host, TcpOptions.Port,
                     closed.ReasonMessage);
-                _ = CleanUpGracefully(true); // idempotent
+                BecomeAborted();
                 break;
             }
+            case BackgroundTasksCompleted:
+            {
+                // Background tasks finished while still in Connected — go straight to shutdown
+                _log.Debug("Background tasks completed while in Connected state.");
+                SendPoisonPillOnce();
+                break;
+            }
+            default:
+                // Ignore unknown messages in Connected state
+                break;
         }
     }
 
-    private async Task CleanUpGracefully(bool waitOnReads = false)
+    /// <summary>
+    /// Draining state — outbound channel writer is completed, waiting for pending outbound data to flush.
+    /// </summary>
+    private void BecomeDraining()
     {
-        // add a simulated DisconnectPacket to help ensure the stream gets terminated
-        _readsFromTransport.Writer.TryWrite(DisconnectToBinary.NormalDisconnectPacket.ToBinary(MqttProtocolVersion.V3_1_1));
+        State.Status = ConnectionStatus.Draining;
+        Become(Draining);
 
-        State.Status = ConnectionStatus.Disconnected;
+        // inject a DisconnectPacket into the reads channel to signal stream termination
+        _readsFromTransport.Writer.TryWrite(DisconnectToBinary.NormalDisconnectPacket.ToBinary(MqttProtocolVersion.V3_1_1));
 
         // no more writes to transport
         _writesToTransport.Writer.TryComplete();
 
-        // wait for any pending writes to finish
-        await State.WaitForPendingWrites;
-
-        if (waitOnReads)
+        // wait for pending writes, then self-tell OutboundFlushed
+        State.WaitForPendingWrites.ContinueWith(_ =>
         {
-            // wait for any reads to finish (should be terminated by Akka.Streams once the `DisconnectPacket` is processed.)
-            await _readsFromTransport.Reader.Completion;
-        }
-        else // if we're not waiting on reads, just complete the reader
-        {
-            _readsFromTransport.Writer.TryComplete();
-        }
+            _closureSelf.Tell(OutboundFlushed.Instance);
+        }, TaskContinuationOptions.ExecuteSynchronously);
+    }
 
-        // Cancel the background tasks gracefully
-        try
+    private void Draining(object message)
+    {
+        switch (message)
         {
-            await State.ShutDownCts.CancelAsync();
+            case OutboundFlushed:
+            {
+                _log.Debug("Outbound flushed in Draining state. Transitioning to Closing.");
+                BecomeClosing();
+                break;
+            }
+            case BackgroundTasksCompleted:
+            {
+                _log.Debug("Background tasks completed while in Draining state. Transitioning to Stopped.");
+                SendPoisonPillOnce();
+                break;
+            }
+            // Ignore duplicate messages that may arrive while draining
+            case DoClose:
+            case ReadFinished:
+            case ConnectionUnexpectedlyClosed:
+                _log.Debug("Ignoring {0} in Draining state.", message.GetType().Name);
+                break;
+            default:
+                break;
         }
-        catch (ObjectDisposedException)
+    }
+
+    /// <summary>
+    /// Closing state — CTS cancelled, waiting for BackgroundTasksCompleted.
+    /// </summary>
+    private void BecomeClosing()
+    {
+        State.Status = ConnectionStatus.Closing;
+        Become(Closing);
+
+        // Inject a disconnect packet so Akka.Streams can detect the shutdown
+        _readsFromTransport.Writer.TryWrite(DisconnectToBinary.NormalDisconnectPacket.ToBinary(MqttProtocolVersion.V3_1_1));
+
+        // Cancel the background tasks
+        TryCancelCts();
+
+        // Complete channels
+        _writesToTransport.Writer.TryComplete();
+        _readsFromTransport.Writer.TryComplete();
+    }
+
+    private void Closing(object message)
+    {
+        switch (message)
         {
-            // Already cancelled, ignore
+            case BackgroundTasksCompleted:
+            {
+                _log.Debug("Background tasks completed in Closing state. Transitioning to Stopped.");
+                SendPoisonPillOnce();
+                break;
+            }
+            // Ignore duplicate messages that may arrive while closing
+            case DoClose:
+            case ReadFinished:
+            case ConnectionUnexpectedlyClosed:
+            case OutboundFlushed:
+                _log.Debug("Ignoring {0} in Closing state.", message.GetType().Name);
+                break;
+            default:
+                break;
         }
+    }
 
-        // Brief delay to allow ongoing operations to complete
-        await Task.Delay(100);
+    /// <summary>
+    /// Aborted state — immediate cancel, no drain wait.
+    /// </summary>
+    private void BecomeAborted()
+    {
+        State.Status = ConnectionStatus.Aborted;
+        Become(Aborted);
 
-        _closureSelf.Tell(PoisonPill.Instance);
+        // Inject a disconnect packet so Akka.Streams can detect the shutdown
+        _readsFromTransport.Writer.TryWrite(DisconnectToBinary.NormalDisconnectPacket.ToBinary(MqttProtocolVersion.V3_1_1));
+
+        // Immediate cancel
+        TryCancelCts();
+
+        // Complete channels
+        _writesToTransport.Writer.TryComplete();
+        _readsFromTransport.Writer.TryComplete();
+    }
+
+    private void Aborted(object message)
+    {
+        switch (message)
+        {
+            case BackgroundTasksCompleted:
+            {
+                _log.Debug("Background tasks completed in Aborted state. Transitioning to Stopped.");
+                SendPoisonPillOnce();
+                break;
+            }
+            // Ignore everything else in Aborted state
+            case DoClose:
+            case ReadFinished:
+            case ConnectionUnexpectedlyClosed:
+            case OutboundFlushed:
+                _log.Debug("Ignoring {0} in Aborted state.", message.GetType().Name);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Thread-safe CTS cancellation — ensures we only cancel once.
+    /// </summary>
+    private void TryCancelCts()
+    {
+        if (Interlocked.CompareExchange(ref _ctsCancelled, 1, 0) == 0)
+        {
+            try
+            {
+                State.ShutDownCts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already disposed, ignore
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sends PoisonPill exactly once.
+    /// </summary>
+    private void SendPoisonPillOnce()
+    {
+        if (!_poisonPillSent)
+        {
+            _poisonPillSent = true;
+            _closureSelf.Tell(PoisonPill.Instance);
+        }
     }
 
     private void DisposeStreamProvider(ConnectionStatus newStatus)
@@ -479,8 +637,8 @@ internal sealed class TcpTransportActor : UntypedActor
         {
             State.Status = newStatus;
 
-            // stop reading from the socket
-            State.ShutDownCts.Cancel();
+            // stop reading from the socket (safe — TryCancelCts guards double-cancel)
+            TryCancelCts();
 
             _pipe.Reader.Complete();
             _pipe.Writer.Complete();

--- a/src/TurboMqtt/IO/Tcp/TcpTransportActor.cs
+++ b/src/TurboMqtt/IO/Tcp/TcpTransportActor.cs
@@ -19,7 +19,7 @@ namespace TurboMqtt.IO.Tcp;
 /// Actor responsible for managing the TCP transport layer for MQTT.
 ///
 /// FSM:
-///   NotStarted (OnReceive) → Created (TransportCreated) → Connecting (via RunTask)
+///   NotStarted (OnReceive) → Created (TransportCreated) → Connecting
 ///   → Connected → Draining → Closing → Stopped
 ///                  Connected → Aborted → Stopped
 /// </summary>
@@ -28,11 +28,9 @@ internal sealed class TcpTransportActor : UntypedActor
     #region Internal Types
 
     /// <summary>
-    /// Mutable state shared between the TcpTransport and the TcpTransportActor.
+    /// Shared state between the TcpTransport wrapper and the TcpTransportActor.
+    /// Status is updated atomically by the actor; all other fields are immutable after construction.
     /// </summary>
-    /// <remarks>
-    /// Can values can only be set by the TcpTransportActor itself.
-    /// </remarks>
     public sealed class ConnectionState
     {
         public ConnectionState(ChannelWriter<(IMemoryOwner<byte> buffer, int readableBytes)> writer,
@@ -51,7 +49,7 @@ internal sealed class TcpTransportActor : UntypedActor
         public ConnectionStatus Status
         {
             get => (ConnectionStatus)Volatile.Read(ref _status);
-            set => Volatile.Write(ref _status, (int)value);
+            internal set => Volatile.Write(ref _status, (int)value);
         }
 
         /// <summary>
@@ -63,7 +61,7 @@ internal sealed class TcpTransportActor : UntypedActor
             return Interlocked.CompareExchange(ref _status, (int)newValue, (int)expected) == (int)expected;
         }
 
-        public CancellationTokenSource ShutDownCts { get; set; } = new();
+        public CancellationTokenSource ShutDownCts { get; } = new();
 
         public int MaxFrameSize { get; }
 
@@ -198,6 +196,14 @@ internal sealed class TcpTransportActor : UntypedActor
         return maxFrameSize * 2;
     }
 
+    /// <summary>
+    /// Logs a structured FSM transition at Info level.
+    /// </summary>
+    private void LogTransition(string fromState, string toState)
+    {
+        _log.Info("Transport [{0}:{1}] FSM: {2} -> {3}", TcpOptions.Host, TcpOptions.Port, fromState, toState);
+    }
+
     protected override void OnReceive(object message)
     {
         switch (message)
@@ -207,8 +213,7 @@ internal sealed class TcpTransportActor : UntypedActor
                 // return the transport to the client
                 var tcpTransport = new TcpTransport(_log, State, Self);
                 Sender.Tell(tcpTransport);
-                _log.Debug("Created new TCP transport for client connecting to [{0}:{1}]", TcpOptions.Host,
-                    TcpOptions.Port);
+                LogTransition("NotStarted", "Created");
                 Become(TransportCreated);
                 break;
             }
@@ -231,26 +236,41 @@ internal sealed class TcpTransportActor : UntypedActor
         {
             case DoConnect connect when State.Status == ConnectionStatus.NotStarted:
             {
+                State.Status = ConnectionStatus.Connecting;
+                LogTransition("Created", "Connecting");
+                Become(Connecting);
+
+                // Compose caller's token with configured connect timeout
+                var connectTimeout = TcpOptions.ConnectTimeout;
+                var timeoutCts = new CancellationTokenSource(connectTimeout);
+                var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(connect.Cancel, timeoutCts.Token);
+
                 RunTask(async () =>
                 {
-                    _log.Info("Attempting to connect to [{0}:{1}]", TcpOptions.Host, TcpOptions.Port);
-
                     var sender = Sender;
-
-                    // set status to connecting
-                    State.Status = ConnectionStatus.Connecting;
 
                     ConnectResult connectResult;
                     try
                     {
-                        _stream = await _streamProvider.ConnectAsync(TcpOptions.Host, TcpOptions.Port, connect.Cancel)
+                        _stream = await _streamProvider.ConnectAsync(TcpOptions.Host, TcpOptions.Port, linkedCts.Token)
                             .ConfigureAwait(false);
                         connectResult = new ConnectResult(ConnectionStatus.Connected, "Connected.");
+                    }
+                    catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !connect.Cancel.IsCancellationRequested)
+                    {
+                        _log.Warning("Connect to [{0}:{1}] timed out after {2}", TcpOptions.Host, TcpOptions.Port, connectTimeout);
+                        connectResult = new ConnectResult(ConnectionStatus.Failed,
+                            $"Connect timed out after {connectTimeout.TotalSeconds:F0}s");
                     }
                     catch (Exception ex)
                     {
                         _log.Error(ex, "Failed to connect to [{0}:{1}]", TcpOptions.Host, TcpOptions.Port);
                         connectResult = new ConnectResult(ConnectionStatus.Failed, ex.Message);
+                    }
+                    finally
+                    {
+                        linkedCts.Dispose();
+                        timeoutCts.Dispose();
                     }
 
                     sender.Tell(connectResult);
@@ -269,17 +289,46 @@ internal sealed class TcpTransportActor : UntypedActor
                 Sender.Tell(new ConnectResult(ConnectionStatus.Connecting, formatted));
                 break;
             }
+            default:
+                Unhandled(message);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Connecting state — async connection attempt is in progress.
+    /// Valid transitions: ConnectResult(Connected) → Connected, ConnectResult(Failed) → Stopped
+    /// </summary>
+    private void Connecting(object message)
+    {
+        switch (message)
+        {
             case ConnectResult { Status: ConnectionStatus.Connected }:
             {
-                _log.Info("Successfully connected to [{0}:{1}]", TcpOptions.Host, TcpOptions.Port);
+                LogTransition("Connecting", "Connected");
                 State.Status = ConnectionStatus.Connected;
-
                 BecomeConnected();
                 break;
             }
-            case ConnectResult { Status: ConnectionStatus.Failed }:
+            case ConnectResult { Status: ConnectionStatus.Failed } result:
             {
-                _log.Error("Failed to connect to [{0}:{1}]: {2}", TcpOptions.Host, TcpOptions.Port, message);
+                _log.Error("Failed to connect to [{0}:{1}]: {2}", TcpOptions.Host, TcpOptions.Port, result.ReasonMessage);
+                LogTransition("Connecting", "Failed");
+                State.Status = ConnectionStatus.Failed;
+                Context.Stop(Self);
+                break;
+            }
+            case DoConnect:
+            {
+                _log.Debug("Ignoring DoConnect in Connecting state — connection attempt already in progress.");
+                Sender.Tell(new ConnectResult(ConnectionStatus.Connecting,
+                    $"Already attempting to connect to [{TcpOptions.Host}:{TcpOptions.Port}]"));
+                break;
+            }
+            case DoClose:
+            {
+                _log.Debug("Received DoClose while Connecting — will abort connection attempt.");
+                LogTransition("Connecting", "Failed");
                 State.Status = ConnectionStatus.Failed;
                 Context.Stop(Self);
                 break;
@@ -439,13 +488,11 @@ internal sealed class TcpTransportActor : UntypedActor
         {
             case DoClose:
             {
-                _log.Debug("Received DoClose in Connected state. Transitioning to Draining.");
                 BecomeDraining();
                 break;
             }
             case ReadFinished:
             {
-                _log.Debug("Received ReadFinished in Connected state. Transitioning to Closing.");
                 BecomeClosing();
                 break;
             }
@@ -460,6 +507,7 @@ internal sealed class TcpTransportActor : UntypedActor
             {
                 // Background tasks finished while still in Connected — go straight to shutdown
                 _log.Debug("Background tasks completed while in Connected state.");
+                LogTransition("Connected", "Stopped");
                 SendPoisonPillOnce();
                 break;
             }
@@ -474,16 +522,14 @@ internal sealed class TcpTransportActor : UntypedActor
     /// </summary>
     private void BecomeDraining()
     {
+        LogTransition("Connected", "Draining");
         State.Status = ConnectionStatus.Draining;
         Become(Draining);
 
-        // inject a DisconnectPacket into the reads channel to signal stream termination
-        _readsFromTransport.Writer.TryWrite(DisconnectToBinary.NormalDisconnectPacket.ToBinary(MqttProtocolVersion.V3_1_1));
-
-        // no more writes to transport
+        // no more writes to transport — completes the channel so the socket writer drains remaining data
         _writesToTransport.Writer.TryComplete();
 
-        // wait for pending writes, then self-tell OutboundFlushed
+        // wait for pending writes to flush, then inject DISCONNECT and transition
         State.WaitForPendingWrites.ContinueWith(_ =>
         {
             _closureSelf.Tell(OutboundFlushed.Instance);
@@ -496,13 +542,15 @@ internal sealed class TcpTransportActor : UntypedActor
         {
             case OutboundFlushed:
             {
-                _log.Debug("Outbound flushed in Draining state. Transitioning to Closing.");
+                // Outbound has flushed — now inject the DISCONNECT signal for Akka.Streams
+                _readsFromTransport.Writer.TryWrite(DisconnectToBinary.NormalDisconnectPacket.ToBinary(MqttProtocolVersion.V3_1_1));
                 BecomeClosing();
                 break;
             }
             case BackgroundTasksCompleted:
             {
-                _log.Debug("Background tasks completed while in Draining state. Transitioning to Stopped.");
+                _log.Debug("Background tasks completed while in Draining state.");
+                LogTransition("Draining", "Stopped");
                 SendPoisonPillOnce();
                 break;
             }
@@ -522,6 +570,7 @@ internal sealed class TcpTransportActor : UntypedActor
     /// </summary>
     private void BecomeClosing()
     {
+        LogTransition(State.Status == ConnectionStatus.Draining ? "Draining" : "Connected", "Closing");
         State.Status = ConnectionStatus.Closing;
         Become(Closing);
 
@@ -542,7 +591,7 @@ internal sealed class TcpTransportActor : UntypedActor
         {
             case BackgroundTasksCompleted:
             {
-                _log.Debug("Background tasks completed in Closing state. Transitioning to Stopped.");
+                LogTransition("Closing", "Stopped");
                 SendPoisonPillOnce();
                 break;
             }
@@ -563,6 +612,7 @@ internal sealed class TcpTransportActor : UntypedActor
     /// </summary>
     private void BecomeAborted()
     {
+        LogTransition("Connected", "Aborted");
         State.Status = ConnectionStatus.Aborted;
         Become(Aborted);
 
@@ -583,7 +633,7 @@ internal sealed class TcpTransportActor : UntypedActor
         {
             case BackgroundTasksCompleted:
             {
-                _log.Debug("Background tasks completed in Aborted state. Transitioning to Stopped.");
+                LogTransition("Aborted", "Stopped");
                 SendPoisonPillOnce();
                 break;
             }

--- a/src/TurboMqtt/IO/Tcp/TlsStreamProvider.cs
+++ b/src/TurboMqtt/IO/Tcp/TlsStreamProvider.cs
@@ -1,0 +1,75 @@
+// -----------------------------------------------------------------------
+// <copyright file="TlsStreamProvider.cs" company="Petabridge, LLC">
+//      Copyright (C) 2024 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net.Security;
+using TurboMqtt.Client;
+
+namespace TurboMqtt.IO.Tcp;
+
+/// <summary>
+/// Creates a TLS-secured TCP connection by wrapping a <see cref="TcpStreamProvider"/>
+/// with an <see cref="SslStream"/> and completing TLS handshake.
+/// </summary>
+internal sealed class TlsStreamProvider : IStreamProvider
+{
+    private readonly TcpStreamProvider _tcpProvider;
+    private readonly MqttClientTlsOptions _tlsOptions;
+    private readonly string _defaultHost;
+    private SslStream? _sslStream;
+
+    public TlsStreamProvider(MqttClientTcpOptions tcpOptions, MqttClientTlsOptions tlsOptions)
+    {
+        _tcpProvider = new TcpStreamProvider(tcpOptions);
+        _tlsOptions = tlsOptions;
+        _defaultHost = tcpOptions.Host;
+    }
+
+    public async Task<Stream> ConnectAsync(string host, int port, CancellationToken ct = default)
+    {
+        var networkStream = await _tcpProvider.ConnectAsync(host, port, ct).ConfigureAwait(false);
+
+        var sslStream = new SslStream(
+            networkStream,
+            leaveInnerStreamOpen: false,
+            _tlsOptions.ServerCertificateValidationCallback);
+
+        var targetHost = _tlsOptions.TargetHost ?? host;
+
+        var authOptions = new SslClientAuthenticationOptions
+        {
+            TargetHost = targetHost,
+            EnabledSslProtocols = _tlsOptions.EnabledSslProtocols,
+            ClientCertificates = _tlsOptions.ClientCertificates
+        };
+
+        await sslStream.AuthenticateAsClientAsync(authOptions, ct).ConfigureAwait(false);
+
+        _sslStream = sslStream;
+        return sslStream;
+    }
+
+    public void Close()
+    {
+        if (_sslStream is not null)
+        {
+            try
+            {
+                _sslStream.Close();
+                _sslStream.Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+                // already disposed
+            }
+            finally
+            {
+                _sslStream = null;
+            }
+        }
+
+        _tcpProvider.Close();
+    }
+}

--- a/tests/TurboMqtt.Container.Tests/EmqxFixture.cs
+++ b/tests/TurboMqtt.Container.Tests/EmqxFixture.cs
@@ -29,6 +29,8 @@ public class EmqxFixture: IAsyncLifetime
 
     public int MqttPort => Container.BrokerTcpPort;
 
+    public int MqttTlsPort => Container.BrokerSslPort;
+
     public async Task InitializeAsync()
     {
         await Container.StartAsync();

--- a/tests/TurboMqtt.Container.Tests/End2End/EmqxMqtt311TlsEnd2EndSpecs.cs
+++ b/tests/TurboMqtt.Container.Tests/End2End/EmqxMqtt311TlsEnd2EndSpecs.cs
@@ -1,0 +1,164 @@
+// -----------------------------------------------------------------------
+// <copyright file="EmqxMqtt311TlsEnd2EndSpecs.cs" company="Petabridge, LLC">
+//      Copyright (C) 2024 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Akka.TestKit.Xunit2;
+using FluentAssertions;
+using TurboMqtt.Client;
+using TurboMqtt.Protocol;
+using Xunit.Abstractions;
+
+namespace TurboMqtt.Container.Tests.End2End;
+
+[Collection(nameof(EmqxCollection))]
+public class EmqxMqtt311TlsEnd2EndSpecs : TestKit
+{
+    private readonly EmqxFixture _fixture;
+    private readonly MqttClientFactory _clientFactory;
+
+    public EmqxMqtt311TlsEnd2EndSpecs(ITestOutputHelper output, EmqxFixture fixture)
+        : base(output: output)
+    {
+        _fixture = fixture;
+        _clientFactory = new MqttClientFactory(Sys);
+    }
+
+    private MqttClientConnectOptions DefaultConnectOptions =>
+        new("test-tls-client", MqttProtocolVersion.V3_1_1)
+        {
+            UserName = "test",
+            Password = "test",
+            KeepAliveSeconds = 60
+        };
+
+    private MqttClientTcpOptions DefaultTcpOptions =>
+        new("localhost", _fixture.MqttTlsPort);
+
+    // EMQX ships with self-signed certs, so we need to accept them
+    private static MqttClientTlsOptions DefaultTlsOptions => new()
+    {
+        ServerCertificateValidationCallback = AcceptAllCertificates
+    };
+
+    private static bool AcceptAllCertificates(
+        object sender,
+        X509Certificate? certificate,
+        X509Chain? chain,
+        SslPolicyErrors sslPolicyErrors) => true;
+
+    [Fact]
+    public async Task ShouldConnectAndDisconnectOverTls()
+    {
+        var client = await _clientFactory.CreateTlsTcpClient(
+            DefaultConnectOptions, DefaultTcpOptions, DefaultTlsOptions);
+
+        using var cts = new CancellationTokenSource(RemainingOrDefault);
+        var connectResult = await client.ConnectAsync(cts.Token);
+        connectResult.IsSuccess.Should().BeTrue();
+        await client.DisconnectAsync(cts.Token);
+        client.IsConnected.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ShouldPublishAndSubscribeOverTls_QoS0()
+    {
+        var client = await _clientFactory.CreateTlsTcpClient(
+            DefaultConnectOptions, DefaultTcpOptions, DefaultTlsOptions);
+
+        using var cts = new CancellationTokenSource(RemainingOrDefault);
+        var connectResult = await client.ConnectAsync(cts.Token);
+        connectResult.IsSuccess.Should().BeTrue();
+
+        var subscribeResult = await client.SubscribeAsync("tls-topic", QualityOfService.AtMostOnce, cts.Token);
+        subscribeResult.IsSuccess.Should().BeTrue();
+
+        var message = new MqttMessage("tls-topic", "hello tls qos0")
+        {
+            QoS = QualityOfService.AtMostOnce,
+            Retain = false
+        };
+
+        var publishResult = await client.PublishAsync(message, cts.Token);
+        publishResult.IsSuccess.Should().BeTrue();
+
+        var receivedMessages = new List<MqttMessage>();
+        await foreach (var received in client.ReceivedMessages.ReadAllAsync(cts.Token))
+        {
+            receivedMessages.Add(received);
+            if (receivedMessages.Count >= 1)
+                break;
+        }
+
+        receivedMessages.Should().HaveCount(1);
+        Encoding.UTF8.GetString(receivedMessages[0].Payload.Span).Should().Be("hello tls qos0");
+
+        await client.DisconnectAsync(cts.Token);
+    }
+
+    [Fact]
+    public async Task ShouldPublishAndSubscribeOverTls_QoS1()
+    {
+        var client = await _clientFactory.CreateTlsTcpClient(
+            DefaultConnectOptions, DefaultTcpOptions, DefaultTlsOptions);
+
+        using var cts = new CancellationTokenSource(RemainingOrDefault);
+        var connectResult = await client.ConnectAsync(cts.Token);
+        connectResult.IsSuccess.Should().BeTrue();
+
+        var subscribeResult = await client.SubscribeAsync("tls-topic-qos1", QualityOfService.AtLeastOnce, cts.Token);
+        subscribeResult.IsSuccess.Should().BeTrue();
+
+        var message = new MqttMessage("tls-topic-qos1", "hello tls qos1")
+        {
+            QoS = QualityOfService.AtLeastOnce,
+            Retain = false
+        };
+
+        var publishResult = await client.PublishAsync(message, cts.Token);
+        publishResult.IsSuccess.Should().BeTrue();
+
+        var receivedMessages = new List<MqttMessage>();
+        await foreach (var received in client.ReceivedMessages.ReadAllAsync(cts.Token))
+        {
+            receivedMessages.Add(received);
+            if (receivedMessages.Count >= 1)
+                break;
+        }
+
+        receivedMessages.Should().HaveCount(1);
+        Encoding.UTF8.GetString(receivedMessages[0].Payload.Span).Should().Be("hello tls qos1");
+
+        await client.DisconnectAsync(cts.Token);
+    }
+
+    [Fact]
+    public async Task ShouldWorkWithCustomServerCertificateValidationCallback()
+    {
+        var callbackInvoked = false;
+
+        var tlsOptions = new MqttClientTlsOptions
+        {
+            ServerCertificateValidationCallback = (_, _, _, _) =>
+            {
+                callbackInvoked = true;
+                return true;
+            }
+        };
+
+        var client = await _clientFactory.CreateTlsTcpClient(
+            DefaultConnectOptions, DefaultTcpOptions, tlsOptions);
+
+        using var cts = new CancellationTokenSource(RemainingOrDefault);
+        var connectResult = await client.ConnectAsync(cts.Token);
+        connectResult.IsSuccess.Should().BeTrue();
+
+        callbackInvoked.Should().BeTrue("the custom certificate validation callback should have been invoked");
+
+        await client.DisconnectAsync(cts.Token);
+    }
+}

--- a/tests/TurboMqtt.Tests/End2End/TcpMqtt311End2EndSpecs.cs
+++ b/tests/TurboMqtt.Tests/End2End/TcpMqtt311End2EndSpecs.cs
@@ -280,13 +280,13 @@ public class TcpMqtt311End2EndSpecs : TransportSpecBase
             MaxReconnectAttempts = 0
         };
         var client = await ClientFactory.CreateTcpClient(DefaultConnectOptions, updatedTcpOptions);
-        
+
         // we are going to do this, intentionally, without a CTS here - this operation MUST FAIL if we are unable to connect
         var connectResult = await client.ConnectAsync();
         connectResult.IsSuccess.Should().BeFalse();
 
         client.IsConnected.Should().BeFalse();
-        
+
         // start up a new server
         var newServer = new FakeMqttTcpServer(new MqttTcpServerOptions("localhost", 21889), MqttProtocolVersion.V3_1_1,
             Sys.Log, TimeSpan.Zero, new DefaultFakeServerHandleFactory());
@@ -297,7 +297,7 @@ public class TcpMqtt311End2EndSpecs : TransportSpecBase
             // now we should be able to connect
             var connectResult2 = await client.ConnectAsync();
             connectResult2.IsSuccess.Should().BeTrue();
-            
+
             client.IsConnected.Should().BeTrue();
             await client.DisconnectAsync();
 
@@ -308,5 +308,190 @@ public class TcpMqtt311End2EndSpecs : TransportSpecBase
         {
             newServer.Shutdown();
         }
+    }
+
+    /// <summary>
+    /// Race condition test: concurrent disconnect + publish must not deadlock or crash.
+    /// Fires a disconnect and multiple publishes concurrently.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentDisconnectAndPublishShouldNotDeadlockOrCrash()
+    {
+        var client = await ClientFactory.CreateTcpClient(DefaultConnectOptions, DefaultTcpOptions);
+
+        using var cts = new CancellationTokenSource(RemainingOrDefault);
+        var connectResult = await client.ConnectAsync(cts.Token);
+        connectResult.IsSuccess.Should().BeTrue();
+
+        // Fire disconnect and publishes concurrently
+        var disconnectTask = Task.Run(async () =>
+        {
+            try
+            {
+                await client.DisconnectAsync(cts.Token);
+            }
+            catch
+            {
+                // disconnect might fail if publish already closed things — that's acceptable
+            }
+        });
+
+        var publishTasks = Enumerable.Range(0, 10).Select(i => Task.Run(async () =>
+        {
+            try
+            {
+                var msg = new MqttMessage(DefaultTopic, $"concurrent-{i}") { QoS = QualityOfService.AtMostOnce };
+                await client.PublishAsync(msg, cts.Token);
+            }
+            catch
+            {
+                // publishes may fail after disconnect — that's acceptable
+            }
+        })).ToArray();
+
+        // The key assertion: nothing deadlocks, everything completes within the timeout
+        await Task.WhenAll(publishTasks.Append(disconnectTask));
+
+        // Client should be terminated
+        await AwaitAssertAsync(() => client.WhenTerminated.IsCompleted.Should().BeTrue(), cancellationToken: cts.Token);
+    }
+
+    /// <summary>
+    /// Race condition test: rapid sequential reconnects (3+ in &lt; 1 second) complete without error.
+    /// </summary>
+    [Fact]
+    public async Task RapidSequentialReconnectsShouldCompleteWithoutError()
+    {
+        var client = await ClientFactory.CreateTcpClient(DefaultConnectOptions, DefaultTcpOptions);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var connectResult = await client.ConnectAsync(cts.Token);
+        connectResult.IsSuccess.Should().BeTrue();
+
+        // subscribe so we can verify reconnect restores subscriptions
+        var subResult = await client.SubscribeAsync(DefaultTopic, QualityOfService.AtLeastOnce, cts.Token);
+        subResult.IsSuccess.Should().BeTrue();
+
+        // Kick the client 3 times in rapid succession
+        for (var i = 0; i < 3; i++)
+        {
+            // Wait for connected state before kicking
+            await AwaitConditionAsync(() => client.IsConnected, cts.Token);
+
+            // Forcefully disconnect
+            _server.TryDisconnectClientSocket(DefaultConnectOptions.ClientId);
+
+            // Small delay to let transport tear down
+            await Task.Delay(100, cts.Token);
+        }
+
+        // After 3 rapid reconnects, client should recover
+        await AwaitConditionAsync(() => client.IsConnected, cts.Token);
+
+        // Verify we can still publish and receive after all the reconnects
+        var mqttMessage = new MqttMessage(DefaultTopic, "after-rapid-reconnects") { QoS = QualityOfService.AtLeastOnce };
+        var pubResult = await client.PublishAsync(mqttMessage, cts.Token);
+        pubResult.IsSuccess.Should().BeTrue();
+
+        (await client.ReceivedMessages.WaitToReadAsync(cts.Token)).Should().BeTrue();
+        client.ReceivedMessages.TryRead(out var received).Should().BeTrue();
+        received!.Topic.Should().Be(DefaultTopic);
+
+        using var shutdownCts = new CancellationTokenSource(RemainingOrDefault);
+        await client.DisconnectAsync(shutdownCts.Token);
+        await client.WhenTerminated.WaitAsync(shutdownCts.Token);
+    }
+
+    /// <summary>
+    /// Race condition test: server kills connection during QoS 2 exchange — client reconnects and retransmits.
+    /// </summary>
+    [Fact]
+    public async Task ServerKillDuringQos2ExchangeShouldReconnectAndRetransmit()
+    {
+        var client = await ClientFactory.CreateTcpClient(DefaultConnectOptions, DefaultTcpOptions);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var connectResult = await client.ConnectAsync(cts.Token);
+        connectResult.IsSuccess.Should().BeTrue();
+
+        // subscribe at QoS 2
+        var subResult = await client.SubscribeAsync(DefaultTopic, QualityOfService.ExactlyOnce, cts.Token);
+        subResult.IsSuccess.Should().BeTrue();
+
+        // Start a QoS 2 publish — this begins the multi-step QoS 2 handshake
+        var publishTask = Task.Run(async () =>
+        {
+            var msg = new MqttMessage(DefaultTopic, "qos2-message") { QoS = QualityOfService.ExactlyOnce };
+            return await client.PublishAsync(msg, cts.Token);
+        });
+
+        // Give the publish time to start the handshake
+        await Task.Delay(50, cts.Token);
+
+        // Kill the server connection mid-exchange
+        _server.TryDisconnectClientSocket(DefaultConnectOptions.ClientId);
+
+        // The publish may fail or succeed depending on timing — either is acceptable
+        try
+        {
+            var pubResult = await publishTask;
+            // If it succeeded, great
+        }
+        catch
+        {
+            // If the publish failed due to disconnect, that's also acceptable
+        }
+
+        // Wait for reconnect to complete
+        await AwaitConditionAsync(() => client.IsConnected, cts.Token);
+
+        // After reconnect, verify we can still publish and receive
+        var newMsg = new MqttMessage(DefaultTopic, "after-qos2-kill") { QoS = QualityOfService.ExactlyOnce };
+        var newPubResult = await client.PublishAsync(newMsg, cts.Token);
+        newPubResult.IsSuccess.Should().BeTrue();
+
+        (await client.ReceivedMessages.WaitToReadAsync(cts.Token)).Should().BeTrue();
+
+        using var shutdownCts = new CancellationTokenSource(RemainingOrDefault);
+        await client.DisconnectAsync(shutdownCts.Token);
+        await client.WhenTerminated.WaitAsync(shutdownCts.Token);
+    }
+
+    /// <summary>
+    /// Race condition test: disconnect while a large publish is in flight — verifies graceful drain.
+    /// </summary>
+    [Fact]
+    public async Task DisconnectDuringLargePublishShouldDrainGracefully()
+    {
+        var client = await ClientFactory.CreateTcpClient(DefaultConnectOptions, DefaultTcpOptions);
+
+        using var cts = new CancellationTokenSource(RemainingOrDefault);
+        var connectResult = await client.ConnectAsync(cts.Token);
+        connectResult.IsSuccess.Should().BeTrue();
+
+        // Start publishing a burst of messages
+        var publishTasks = Enumerable.Range(0, 50).Select(i =>
+        {
+            var msg = new MqttMessage(DefaultTopic, $"large-publish-{i}") { QoS = QualityOfService.AtMostOnce };
+            return client.PublishAsync(msg, cts.Token);
+        }).ToArray();
+
+        // Initiate graceful disconnect while publishes are in flight
+        var disconnectTask = client.DisconnectAsync(cts.Token);
+
+        // All operations should complete without deadlock or crash
+        try
+        {
+            await Task.WhenAll(publishTasks);
+        }
+        catch
+        {
+            // Some publishes may fail if disconnect completes first — acceptable
+        }
+
+        await disconnectTask;
+
+        // Client should be terminated
+        await AwaitAssertAsync(() => client.WhenTerminated.IsCompleted.Should().BeTrue(), cancellationToken: cts.Token);
     }
 }

--- a/tests/TurboMqtt.Tests/IO/Tcp/TcpStreamProviderSpecs.cs
+++ b/tests/TurboMqtt.Tests/IO/Tcp/TcpStreamProviderSpecs.cs
@@ -1,0 +1,176 @@
+// -----------------------------------------------------------------------
+// <copyright file="TcpStreamProviderSpecs.cs" company="Petabridge, LLC">
+//      Copyright (C) 2024 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net;
+using System.Net.Sockets;
+using FluentAssertions;
+using TurboMqtt.IO.Tcp;
+
+namespace TurboMqtt.Tests.IO.Tcp;
+
+public class TcpStreamProviderSpecs : IDisposable
+{
+    private Socket? _listener;
+    private TcpStreamProvider? _provider;
+    private int _port;
+
+    private void StartListener()
+    {
+        _listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        _listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        _listener.Listen(1);
+        _port = ((IPEndPoint)_listener.LocalEndPoint!).Port;
+    }
+
+    public void Dispose()
+    {
+        _provider?.Close();
+        _listener?.Close();
+        _listener?.Dispose();
+    }
+
+    [Fact]
+    public async Task ConnectAsync_ShouldReturnNetworkStream_WhenServerIsListening()
+    {
+        // Arrange
+        StartListener();
+        _provider = new TcpStreamProvider(AddressFamily.Unspecified, 128 * 1024);
+
+        // Act
+        var stream = await _provider.ConnectAsync("localhost", _port);
+
+        // Assert
+        stream.Should().NotBeNull();
+        stream.Should().BeOfType<NetworkStream>();
+        stream.CanRead.Should().BeTrue();
+        stream.CanWrite.Should().BeTrue();
+
+        stream.Close();
+    }
+
+    [Fact]
+    public async Task ConnectAsync_ShouldResolveLocalhost_ViaHostname()
+    {
+        // Arrange
+        StartListener();
+        _provider = new TcpStreamProvider(AddressFamily.Unspecified, 128 * 1024);
+
+        // Act — "localhost" requires DNS resolution
+        var stream = await _provider.ConnectAsync("localhost", _port);
+
+        // Assert
+        stream.Should().NotBeNull();
+
+        stream.Close();
+    }
+
+    [Fact]
+    public async Task ConnectAsync_ShouldThrow_WhenServerIsNotListening()
+    {
+        // Arrange — use a port that nothing is listening on
+        _provider = new TcpStreamProvider(AddressFamily.Unspecified, 128 * 1024);
+
+        // Act & Assert
+        var act = () => _provider.ConnectAsync("localhost", 1);
+        await act.Should().ThrowAsync<SocketException>();
+    }
+
+    [Fact]
+    public async Task ConnectAsync_ShouldThrow_WhenHostCannotBeResolved()
+    {
+        // Arrange
+        _provider = new TcpStreamProvider(AddressFamily.Unspecified, 128 * 1024);
+
+        // Act & Assert
+        var act = () => _provider.ConnectAsync("this-host-does-not-exist-xyz123.invalid", 1883);
+        await act.Should().ThrowAsync<SocketException>();
+    }
+
+    [Fact]
+    public async Task ConnectAsync_ShouldRespectCancellation()
+    {
+        // Arrange
+        _provider = new TcpStreamProvider(AddressFamily.Unspecified, 128 * 1024);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Act & Assert
+        var act = () => _provider.ConnectAsync("localhost", 1883, cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task ConnectAsync_ShouldConfigureSocket_WithExpectedBufferSizes()
+    {
+        // Arrange
+        StartListener();
+        var maxFrameSize = 128 * 1024;
+        _provider = new TcpStreamProvider(AddressFamily.Unspecified, maxFrameSize);
+
+        // Act
+        var stream = await _provider.ConnectAsync("localhost", _port);
+
+        // Accept the connection on the server side so we can verify it connected
+        var serverSocket = await _listener!.AcceptAsync();
+        serverSocket.Connected.Should().BeTrue();
+
+        // Assert — the stream is usable
+        stream.Should().NotBeNull();
+
+        serverSocket.Close();
+        stream.Close();
+    }
+
+    [Fact]
+    public void Close_ShouldBeIdempotent()
+    {
+        // Arrange
+        _provider = new TcpStreamProvider(AddressFamily.Unspecified, 128 * 1024);
+
+        // Act — close before any connection was made
+        var act = () =>
+        {
+            _provider.Close();
+            _provider.Close();
+        };
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task Close_ShouldCleanUpSocket_AfterSuccessfulConnect()
+    {
+        // Arrange
+        StartListener();
+        _provider = new TcpStreamProvider(AddressFamily.Unspecified, 128 * 1024);
+        var stream = await _provider.ConnectAsync("localhost", _port);
+
+        // Act
+        stream.Close();
+        _provider.Close();
+
+        // Assert — calling Close again should not throw
+        var act = () => _provider.Close();
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task ConnectAsync_WithExplicitAddressFamily_ShouldWork()
+    {
+        // Arrange
+        StartListener();
+        _provider = new TcpStreamProvider(AddressFamily.InterNetwork, 128 * 1024);
+
+        // Act
+        var stream = await _provider.ConnectAsync("127.0.0.1", _port);
+
+        // Assert
+        stream.Should().NotBeNull();
+
+        stream.Close();
+    }
+}

--- a/tests/TurboMqtt.Tests/IO/Tcp/TcpTransportActorSpecs.cs
+++ b/tests/TurboMqtt.Tests/IO/Tcp/TcpTransportActorSpecs.cs
@@ -1,0 +1,485 @@
+// -----------------------------------------------------------------------
+// <copyright file="TcpTransportActorSpecs.cs" company="Petabridge, LLC">
+//      Copyright (C) 2024 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Buffers;
+using Akka.Actor;
+using Akka.TestKit.Xunit2;
+using FluentAssertions;
+using TurboMqtt.Client;
+using TurboMqtt.IO;
+using TurboMqtt.IO.Tcp;
+using Xunit.Abstractions;
+
+namespace TurboMqtt.Tests.IO.Tcp;
+
+/// <summary>
+/// A controllable <see cref="IStreamProvider"/> for testing the <see cref="TcpTransportActor"/> FSM.
+/// </summary>
+internal sealed class FakeStreamProvider : IStreamProvider
+{
+    private readonly TaskCompletionSource<Stream> _connectTcs = new();
+    private readonly FakeStream _stream;
+    private bool _closed;
+
+    public FakeStreamProvider(FakeStream? stream = null)
+    {
+        _stream = stream ?? new FakeStream();
+    }
+
+    public FakeStream Stream => _stream;
+
+    /// <summary>
+    /// Complete the pending ConnectAsync call successfully.
+    /// </summary>
+    public void CompleteConnect() => _connectTcs.TrySetResult(_stream);
+
+    /// <summary>
+    /// Fail the pending ConnectAsync call.
+    /// </summary>
+    public void FailConnect(Exception ex) => _connectTcs.TrySetException(ex);
+
+    public async Task<Stream> ConnectAsync(string host, int port, CancellationToken ct = default)
+    {
+        await using var reg = ct.Register(() => _connectTcs.TrySetCanceled(ct));
+        return await _connectTcs.Task.ConfigureAwait(false);
+    }
+
+    public void Close()
+    {
+        _closed = true;
+        _stream.Shutdown();
+    }
+
+    public bool IsClosed => _closed;
+}
+
+/// <summary>
+/// A controllable <see cref="Stream"/> that blocks reads until data is written or the stream is shut down.
+/// </summary>
+internal sealed class FakeStream : Stream
+{
+    private readonly SemaphoreSlim _dataAvailable = new(0);
+    private readonly object _lock = new();
+    private readonly Queue<byte[]> _readQueue = new();
+    private bool _shutdown;
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => true;
+    public override long Length => throw new NotSupportedException();
+    public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+    /// <summary>
+    /// Enqueue data that will be returned by the next ReadAsync call.
+    /// </summary>
+    public void EnqueueReadData(byte[] data)
+    {
+        lock (_lock)
+        {
+            _readQueue.Enqueue(data);
+        }
+        _dataAvailable.Release();
+    }
+
+    /// <summary>
+    /// Signal the stream to stop — ReadAsync will return 0 (graceful close).
+    /// </summary>
+    public void Shutdown()
+    {
+        _shutdown = true;
+        _dataAvailable.Release();
+    }
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        await _dataAvailable.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        lock (_lock)
+        {
+            if (_readQueue.TryDequeue(out var data))
+            {
+                var toCopy = Math.Min(data.Length, buffer.Length);
+                data.AsMemory(0, toCopy).CopyTo(buffer);
+                return toCopy;
+            }
+        }
+
+        // No data and shutdown — return 0 (graceful close)
+        if (_shutdown)
+            return 0;
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Track how many bytes have been written.
+    /// </summary>
+    public long TotalBytesWritten;
+
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Interlocked.Add(ref TotalBytesWritten, buffer.Length);
+        return ValueTask.CompletedTask;
+    }
+
+    public override void Flush() { }
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Tests for the <see cref="TcpTransportActor"/> FSM — verifies all state transitions,
+/// connect timeout, abort path, and graceful drain behavior.
+/// </summary>
+public class TcpTransportActorSpecs : TestKit
+{
+    private static readonly MqttClientTcpOptions DefaultTcpOptions = new("localhost", 1883)
+    {
+        ConnectTimeout = TimeSpan.FromSeconds(5)
+    };
+
+    public TcpTransportActorSpecs(ITestOutputHelper output) : base(output: output)
+    {
+    }
+
+    private (IActorRef actor, FakeStreamProvider provider) CreateActor(MqttClientTcpOptions? options = null)
+    {
+        var provider = new FakeStreamProvider();
+        var opts = options ?? DefaultTcpOptions;
+        var actor = Sys.ActorOf(Props.Create(() => new TcpTransportActor(opts, provider)));
+        return (actor, provider);
+    }
+
+    #region FSM State Transition Tests
+
+    [Fact]
+    public async Task Should_transition_NotStarted_to_Created_on_CreateTcpTransport()
+    {
+        var (actor, _) = CreateActor();
+
+        var transport = await actor.Ask<IMqttTransport>(TcpTransportActor.CreateTcpTransport.Instance, TimeSpan.FromSeconds(3));
+
+        transport.Should().NotBeNull();
+        transport.Status.Should().Be(ConnectionStatus.NotStarted); // status stays NotStarted until DoConnect
+    }
+
+    [Fact]
+    public async Task Should_transition_Created_to_Connecting_to_Connected()
+    {
+        var (actor, provider) = CreateActor();
+
+        // NotStarted → Created
+        var transport = await actor.Ask<IMqttTransport>(TcpTransportActor.CreateTcpTransport.Instance, TimeSpan.FromSeconds(3));
+
+        // Created → Connecting → Connected
+        // Complete the connection asynchronously
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            provider.CompleteConnect();
+        });
+
+        var result = await actor.Ask<TcpTransportActor.ConnectResult>(
+            new TcpTransportActor.DoConnect(CancellationToken.None), TimeSpan.FromSeconds(5));
+
+        result.Status.Should().Be(ConnectionStatus.Connected);
+
+        // The actor processes the self-tell asynchronously — wait for state to settle
+        await AwaitConditionAsync(() => Task.FromResult(transport.Status == ConnectionStatus.Connected), TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
+    public async Task Should_transition_full_happy_path_NotStarted_to_Stopped()
+    {
+        var (actor, provider) = CreateActor();
+
+        // Watch for termination
+        Watch(actor);
+
+        // NotStarted → Created
+        var transport = await actor.Ask<IMqttTransport>(TcpTransportActor.CreateTcpTransport.Instance, TimeSpan.FromSeconds(3));
+
+        // Created → Connecting → Connected
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            provider.CompleteConnect();
+        });
+
+        var result = await actor.Ask<TcpTransportActor.ConnectResult>(
+            new TcpTransportActor.DoConnect(CancellationToken.None), TimeSpan.FromSeconds(5));
+        result.Status.Should().Be(ConnectionStatus.Connected);
+
+        // Connected → Draining → Closing → Stopped
+        actor.Tell(new TcpTransportActor.DoClose(CancellationToken.None));
+
+        // Actor should terminate
+        await ExpectTerminatedAsync(actor, TimeSpan.FromSeconds(10));
+
+        // Final status should be Disconnected (set in PostStop/FullShutdown)
+        transport.Status.Should().Be(ConnectionStatus.Disconnected);
+    }
+
+    [Fact]
+    public async Task Should_transition_Connecting_to_Failed_on_connection_error()
+    {
+        var (actor, provider) = CreateActor();
+
+        Watch(actor);
+
+        // NotStarted → Created
+        await actor.Ask<IMqttTransport>(TcpTransportActor.CreateTcpTransport.Instance, TimeSpan.FromSeconds(3));
+
+        // Created → Connecting → Failed
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            provider.FailConnect(new InvalidOperationException("Connection refused"));
+        });
+
+        var result = await actor.Ask<TcpTransportActor.ConnectResult>(
+            new TcpTransportActor.DoConnect(CancellationToken.None), TimeSpan.FromSeconds(5));
+
+        result.Status.Should().Be(ConnectionStatus.Failed);
+        result.ReasonMessage.Should().Contain("Connection refused");
+
+        // Actor should stop
+        await ExpectTerminatedAsync(actor, TimeSpan.FromSeconds(5));
+    }
+
+    #endregion
+
+    #region Aborted Short-Circuit Tests
+
+    [Fact]
+    public async Task Should_transition_Connected_to_Aborted_on_unexpected_close()
+    {
+        var (actor, provider) = CreateActor();
+
+        Watch(actor);
+
+        // NotStarted → Created → Connected
+        var transport = await actor.Ask<IMqttTransport>(TcpTransportActor.CreateTcpTransport.Instance, TimeSpan.FromSeconds(3));
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            provider.CompleteConnect();
+        });
+
+        var result = await actor.Ask<TcpTransportActor.ConnectResult>(
+            new TcpTransportActor.DoConnect(CancellationToken.None), TimeSpan.FromSeconds(5));
+        result.Status.Should().Be(ConnectionStatus.Connected);
+
+        // Simulate unexpected close — shut down the stream so ReadAsync returns 0
+        provider.Stream.Shutdown();
+
+        // Actor should terminate via ReadFinished → Closing → Stopped
+        await ExpectTerminatedAsync(actor, TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task Should_transition_Connected_to_Aborted_on_ConnectionUnexpectedlyClosed()
+    {
+        var (actor, provider) = CreateActor();
+
+        Watch(actor);
+
+        // Get to Connected state
+        await actor.Ask<IMqttTransport>(TcpTransportActor.CreateTcpTransport.Instance, TimeSpan.FromSeconds(3));
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            provider.CompleteConnect();
+        });
+
+        var connectResult = await actor.Ask<TcpTransportActor.ConnectResult>(
+            new TcpTransportActor.DoConnect(CancellationToken.None), TimeSpan.FromSeconds(5));
+        connectResult.Status.Should().Be(ConnectionStatus.Connected);
+
+        // Send ConnectionUnexpectedlyClosed directly
+        actor.Tell(new TcpTransportActor.ConnectionUnexpectedlyClosed(
+            TurboMqtt.PacketTypes.DisconnectReasonCode.UnspecifiedError, "Broker killed connection"));
+
+        // Actor should terminate
+        await ExpectTerminatedAsync(actor, TimeSpan.FromSeconds(10));
+    }
+
+    #endregion
+
+    #region Drain During Publish Tests
+
+    [Fact]
+    public async Task Should_flush_outbound_before_close_during_drain()
+    {
+        var (actor, provider) = CreateActor();
+
+        Watch(actor);
+
+        // Get to Connected state
+        var transport = await actor.Ask<IMqttTransport>(TcpTransportActor.CreateTcpTransport.Instance, TimeSpan.FromSeconds(3));
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            provider.CompleteConnect();
+        });
+
+        var result = await actor.Ask<TcpTransportActor.ConnectResult>(
+            new TcpTransportActor.DoConnect(CancellationToken.None), TimeSpan.FromSeconds(5));
+        result.Status.Should().Be(ConnectionStatus.Connected);
+
+        // Write some data to the outbound channel — simulating a large publish in flight
+        var data = new byte[4096];
+        Random.Shared.NextBytes(data);
+        var pooled = MemoryPool<byte>.Shared.Rent(data.Length);
+        data.CopyTo(pooled.Memory);
+        transport.Writer.TryWrite((pooled, data.Length)).Should().BeTrue();
+
+        // Give the write task a moment to pick up the data
+        await Task.Delay(100);
+
+        // Request graceful close — should enter Draining, wait for flush, then Closing
+        actor.Tell(new TcpTransportActor.DoClose(CancellationToken.None));
+
+        // Actor should eventually terminate
+        await ExpectTerminatedAsync(actor, TimeSpan.FromSeconds(10));
+
+        // Verify data was written to the stream before shutdown
+        provider.Stream.TotalBytesWritten.Should().BeGreaterOrEqualTo(data.Length);
+    }
+
+    #endregion
+
+    #region Connect Timeout Tests
+
+    [Fact]
+    public async Task Should_fail_connect_when_timeout_expires()
+    {
+        // Use a very short timeout
+        var options = new MqttClientTcpOptions("unreachable.host", 1883)
+        {
+            ConnectTimeout = TimeSpan.FromMilliseconds(200)
+        };
+
+        var provider = new FakeStreamProvider();
+        var actor = Sys.ActorOf(Props.Create(() => new TcpTransportActor(options, provider)));
+
+        Watch(actor);
+
+        // NotStarted → Created
+        await actor.Ask<IMqttTransport>(TcpTransportActor.CreateTcpTransport.Instance, TimeSpan.FromSeconds(3));
+
+        // Don't complete the connection — let it time out
+        var result = await actor.Ask<TcpTransportActor.ConnectResult>(
+            new TcpTransportActor.DoConnect(CancellationToken.None), TimeSpan.FromSeconds(5));
+
+        result.Status.Should().Be(ConnectionStatus.Failed);
+        result.ReasonMessage.Should().Contain("timed out");
+
+        // Actor should stop after failed connect
+        await ExpectTerminatedAsync(actor, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task Should_respect_caller_cancellation_over_timeout()
+    {
+        var options = new MqttClientTcpOptions("localhost", 1883)
+        {
+            ConnectTimeout = TimeSpan.FromSeconds(30) // long timeout
+        };
+
+        var provider = new FakeStreamProvider();
+        var actor = Sys.ActorOf(Props.Create(() => new TcpTransportActor(options, provider)));
+
+        Watch(actor);
+
+        await actor.Ask<IMqttTransport>(TcpTransportActor.CreateTcpTransport.Instance, TimeSpan.FromSeconds(3));
+
+        // Cancel quickly via caller token
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        var result = await actor.Ask<TcpTransportActor.ConnectResult>(
+            new TcpTransportActor.DoConnect(cts.Token), TimeSpan.FromSeconds(5));
+
+        result.Status.Should().Be(ConnectionStatus.Failed);
+
+        await ExpectTerminatedAsync(actor, TimeSpan.FromSeconds(5));
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Fact]
+    public async Task Should_ignore_duplicate_DoClose_in_Draining_state()
+    {
+        var (actor, provider) = CreateActor();
+
+        Watch(actor);
+
+        // Get to Connected state
+        await actor.Ask<IMqttTransport>(TcpTransportActor.CreateTcpTransport.Instance, TimeSpan.FromSeconds(3));
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            provider.CompleteConnect();
+        });
+
+        var result = await actor.Ask<TcpTransportActor.ConnectResult>(
+            new TcpTransportActor.DoConnect(CancellationToken.None), TimeSpan.FromSeconds(5));
+        result.Status.Should().Be(ConnectionStatus.Connected);
+
+        // Send multiple DoClose messages — should not crash
+        actor.Tell(new TcpTransportActor.DoClose(CancellationToken.None));
+        actor.Tell(new TcpTransportActor.DoClose(CancellationToken.None));
+        actor.Tell(new TcpTransportActor.DoClose(CancellationToken.None));
+
+        // Actor should still terminate cleanly
+        await ExpectTerminatedAsync(actor, TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task Should_not_crash_when_DoConnect_arrives_in_Connected_state()
+    {
+        var (actor, provider) = CreateActor();
+
+        Watch(actor);
+
+        var transport = await actor.Ask<IMqttTransport>(TcpTransportActor.CreateTcpTransport.Instance, TimeSpan.FromSeconds(3));
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            provider.CompleteConnect();
+        });
+
+        var result = await actor.Ask<TcpTransportActor.ConnectResult>(
+            new TcpTransportActor.DoConnect(CancellationToken.None), TimeSpan.FromSeconds(5));
+        result.Status.Should().Be(ConnectionStatus.Connected);
+
+        // Wait for actor to fully transition
+        await AwaitConditionAsync(() => Task.FromResult(transport.Status == ConnectionStatus.Connected), TimeSpan.FromSeconds(3));
+
+        // Send a spurious DoConnect via Tell — should be silently ignored (Connected swallows unknown messages)
+        actor.Tell(new TcpTransportActor.DoConnect(CancellationToken.None));
+
+        // Actor should still be alive and healthy
+        await Task.Delay(200);
+        transport.Status.Should().Be(ConnectionStatus.Connected);
+
+        // Clean shutdown
+        actor.Tell(new TcpTransportActor.DoClose(CancellationToken.None));
+        await ExpectTerminatedAsync(actor, TimeSpan.FromSeconds(10));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Complete transport layer redesign (Phase 2.5) addressing 12+ race conditions, adding memory pooling, Stream abstraction, TLS support, and transport lifecycle hardening.

- **Task 2.5-A**: Extract `IStreamProvider` abstraction, replace raw `Socket` with `Stream`, pool read allocations via `MemoryPool<byte>.Shared`
- **Task 2.5-B**: Fix 12+ transport race conditions with explicit FSM state machine (`NotStarted → Created → Connecting → Connected → Draining → Closing → Stopped`)
- **Task 2.5-C**: Add TLS support via `TlsStreamProvider` wrapping `SslStream`, new `MqttClientTlsOptions` and `CreateTlsTcpClient()` factory method
- **Task 2.5-D**: Harden transport lifecycle with connect timeout, graceful drain ordering, and structured state transition logging
- Reconnect logging fix (silent subscription failure during reconnect now warns)
- README updated with TLS documentation
- 5 resolved backlog items cleaned up, Phase 2.5 checkboxes synced

## Test plan

- [x] 237 unit tests pass (`dotnet test tests/TurboMqtt.Tests/ -c Release`)
- [x] 15 container tests pass against EMQX 5.5.1 (`dotnet test tests/TurboMqtt.Container.Tests/ -c Release`)
- [x] New `TcpStreamProviderSpecs` (9 tests) — DNS resolution, socket config, connection lifecycle
- [x] New `TcpTransportActorSpecs` (15 tests) — FSM transitions, concurrent disconnect, rapid reconnect, graceful drain
- [x] New `EmqxMqtt311TlsEnd2EndSpecs` (4 tests) — TLS connect, QoS 0/1 pub/sub over TLS, custom cert validation
- [x] BenchmarkDotNet: no throughput regression (319k req/sec QoS 0 @ 10B payload)
- [x] Zero compiler warnings