### PR TITLE
Phase 1 completion + Phase 2 codec hardening (Tasks 1.6-2.2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,8 +3,6 @@
     <Copyright>Copyright © 2024 Petabridge, LLC</Copyright>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- NuGet audit: only fail on high/critical vulnerabilities. Moderate OTEL vuln tracked in Task 1.5 -->
-    <NuGetAuditLevel>high</NuGetAuditLevel>
     <VersionPrefix>0.1.1</VersionPrefix>
     <Authors>Petabridge</Authors>
     <PackageReleaseNotes>TurboMqtt v0.1.1 includes critical bug fixes and massive performance improvements over v0.1.0.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Copyright>Copyright © 2024 Petabridge, LLC</Copyright>
+    <Copyright>Copyright © 2025 Petabridge, LLC</Copyright>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.1.1</VersionPrefix>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Copyright>Copyright © 2025 Petabridge, LLC</Copyright>
+    <Copyright>Copyright © 2024-$([System.DateTime]::Now.Year) Petabridge, LLC</Copyright>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.1.1</VersionPrefix>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,17 +31,17 @@
   <ItemGroup>
     <PackageVersion Include="Akka.Hosting.TestKit" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="Akka.Streams.TestKit" Version="$(AkkaVersion)" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
-    <PackageVersion Include="Verify.Xunit" Version="17.10.2" />
-    <PackageVersion Include="Verify.DiffPlex" Version="1.3.0" />
-    <PackageVersion Include="Testcontainers" Version="4.1.0" />
-    <PackageVersion Include="Testcontainers.ActiveMq" Version="3.8.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.8.0" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
+    <PackageVersion Include="Verify.Xunit" Version="31.12.5" />
+    <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
+    <PackageVersion Include="Testcontainers" Version="4.10.0" />
+    <PackageVersion Include="Testcontainers.ActiveMq" Version="4.10.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="FsCheck.Xunit" Version="2.16.6" />
   </ItemGroup>

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -160,10 +160,10 @@ PubComp, Subscribe, SubAck, Unsubscribe, UnsubAck, PingReq, PingResp, Disconnect
 Update `PacketArb()` to include all 14 generators.
 
 Done when:
-- [ ] `PacketGenerators.cs` has an `Arbitrary<MqttPacket>` generator for each of the 14 MQTT 3.1.1 packet types
-- [ ] Each generator produces valid packets with randomized field values within spec constraints
-- [ ] `PacketArb()` uses `Gen.OneOf(...)` over all 14 generators
-- [ ] All generators compile and produce non-null packets when sampled (add a smoke test if needed)
+- [x] `PacketGenerators.cs` has an `Arbitrary<MqttPacket>` generator for each of the 14 MQTT 3.1.1 packet types
+- [x] Each generator produces valid packets with randomized field values within spec constraints
+- [x] `PacketArb()` uses `Gen.OneOf(...)` over all 14 generators
+- [x] All generators compile and produce non-null packets when sampled (add a smoke test if needed)
 
 ### Task 2.2: Expand ConnectPacket generator to cover Will, Username, Password
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -176,11 +176,11 @@ The current `ConnectPacketArb()` only generates `ClientId`, `CleanSession`, and
 retain), Username, and Password fields that are controlled by `ConnectFlags`.
 
 Done when:
-- [ ] `ConnectPacketArb()` randomly generates packets with and without Will messages
-- [ ] Will topic, Will message payload, Will QoS (0/1/2), and Will retain are randomized when Will is present
-- [ ] Username and Password fields are randomly included or omitted
-- [ ] `ConnectFlags` bits are consistent with the fields present (e.g., `HasWill=true` when Will topic is set)
-- [ ] Existing roundtrip codec tests still pass
+- [x] `ConnectPacketArb()` randomly generates packets with and without Will messages
+- [x] Will topic, Will message payload, Will QoS (0/1/2), and Will retain are randomized when Will is present
+- [x] Username and Password fields are randomly included or omitted
+- [x] `ConnectFlags` bits are consistent with the fields present (e.g., `HasWill=true` when Will topic is set)
+- [x] Existing roundtrip codec tests still pass
 
 ### Task 2.3: Add roundtrip encode/decode property tests for all packet types
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -132,12 +132,12 @@ Done when:
 **Verification:** L0
 
 Done when:
-- [ ] `PROJECT_CONTEXT.md` version updated to reflect 0.3.0-beta (or whatever version is chosen for this release cycle)
-- [ ] `PROJECT_CONTEXT.md` "Key Constraints" reflects `net10.0` and current Akka version
-- [ ] `TOOLING.md` reflects all updated tool/package versions
-- [ ] `TOOLING.md` Build table `.NET SDK` version updated from `8.0.400` to `10.0.100` *(source: RALPH run 20260219-215639 CLEANUP item -- stale after Task 1.3 .NET 10 upgrade)*
-- [ ] `TOOLING.md` CI/CD section describes GitHub Actions release pipeline (not Azure DevOps)
-- [ ] `Directory.Build.props` copyright year updated to 2025
+- [x] `PROJECT_CONTEXT.md` version updated to reflect 0.3.0-beta (or whatever version is chosen for this release cycle)
+- [x] `PROJECT_CONTEXT.md` "Key Constraints" reflects `net10.0` and current Akka version
+- [x] `TOOLING.md` reflects all updated tool/package versions
+- [x] `TOOLING.md` Build table `.NET SDK` version updated from `8.0.400` to `10.0.100` *(source: RALPH run 20260219-215639 CLEANUP item -- stale after Task 1.3 .NET 10 upgrade)*
+- [x] `TOOLING.md` CI/CD section describes GitHub Actions release pipeline (not Azure DevOps)
+- [x] `Directory.Build.props` copyright year updated to 2025
 
 ---
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -115,15 +115,15 @@ Update remaining packages: xunit, FluentAssertions, Testcontainers, BenchmarkDot
 FsCheck, Microsoft.NET.Test.Sdk, coverlet, and other test/tooling dependencies.
 
 Done when:
-- [ ] All packages in `Directory.Packages.props` `Test Package Versions` ItemGroup updated to latest stable
-- [ ] `Microsoft.Extensions.DependencyInjection.Abstractions` and `Microsoft.Extensions.Hosting` updated to `10.0.x` *(note: already completed in Task 1.5/iter-05 due to OTEL transitive dependency)*
-- [ ] Revert `NuGetAuditLevel=high` in `Directory.Build.props` (added in Task 1.3 for OTEL vulnerability, resolved by Task 1.5 OTEL 1.15.0 update; confirm `dotnet build -c Release` produces zero audit warnings after removal) *(source: RALPH run 20260219-215639 CLEANUP item)*
-- [ ] `FsCheck` and `FsCheck.Xunit` updated to latest 2.x stable (or 3.x if compatible)
-- [ ] `BenchmarkDotNet` updated to latest stable
-- [ ] `Testcontainers` updated to latest stable
-- [ ] `dotnet build -c Release` succeeds with zero warnings across all projects
-- [ ] `dotnet test tests/TurboMqtt.Tests/ -c Release` passes
-- [ ] `TOOLING.md` package version table updated
+- [x] All packages in `Directory.Packages.props` `Test Package Versions` ItemGroup updated to latest stable
+- [x] `Microsoft.Extensions.DependencyInjection.Abstractions` and `Microsoft.Extensions.Hosting` updated to `10.0.x` *(note: already completed in Task 1.5/iter-05 due to OTEL transitive dependency)*
+- [x] Revert `NuGetAuditLevel=high` in `Directory.Build.props` (added in Task 1.3 for OTEL vulnerability, resolved by Task 1.5 OTEL 1.15.0 update; confirm `dotnet build -c Release` produces zero audit warnings after removal) *(source: RALPH run 20260219-215639 CLEANUP item)*
+- [x] `FsCheck` and `FsCheck.Xunit` updated to latest 2.x stable (or 3.x if compatible) *(FsCheck 3.x requires C# LINQ API migration to FsCheck.Fluent; staying on 2.16.6 which is already latest 2.x)*
+- [x] `BenchmarkDotNet` updated to latest stable *(0.15.8 — already at latest as of this iteration)*
+- [x] `Testcontainers` updated to latest stable *(4.10.0; also synced Testcontainers.ActiveMq from 3.8.0 → 4.10.0)*
+- [x] `dotnet build -c Release` succeeds with zero warnings across all projects
+- [x] `dotnet test tests/TurboMqtt.Tests/ -c Release` passes
+- [x] `TOOLING.md` package version table updated
 
 ### Task 1.7: Update PROJECT_CONTEXT.md and TOOLING.md for Phase 1
 

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -51,7 +51,7 @@ ActorSystem
 
 ### Key Constraints
 
-- Akka.NET is a core architectural dependency
+- Akka.NET is a core architectural dependency (current version: 1.5.60)
 - AOT compatibility is a longer-term goal, blocked on Akka.NET v1.6
 - `TreatWarningsAsErrors` is enabled globally
 - `AllowUnsafeBlocks` is enabled for performance-critical code paths
@@ -59,7 +59,7 @@ ActorSystem
 
 ## Current State
 
-- **Version**: 0.2.0 (pre-1.0, last release June 2024)
+- **Version**: 0.3.0-beta (in-progress; last published release was 0.2.0, June 2024)
 - **Priority**: MQTT 3.1.1 production readiness (epic #66)
 - **Known issues**: CI/CD GitHub Release broken (#74), flaky test (#99), dependabot PR backlog
 - **In-flight features**: AOT canary, decoder perf optimization

--- a/TOOLING.md
+++ b/TOOLING.md
@@ -9,7 +9,7 @@
 
 | Tool | Version | Access | Purpose |
 |------|---------|--------|---------|
-| .NET SDK | 8.0.400 (pinned in `global.json`, rollForward: latestMinor) | `dotnet` | Build, test, pack |
+| .NET SDK | 10.0.100 (pinned in `global.json`, rollForward: latestMinor) | `dotnet` | Build, test, pack |
 | `build.ps1` | - | `pwsh build.ps1` | Extracts version + release notes from RELEASE_NOTES.md, updates Directory.Build.props |
 | `dotnet sign` | 0.9.x | Installed in release workflow | NuGet package code signing (via Azure Key Vault) |
 
@@ -24,12 +24,12 @@
 
 | Tool | Purpose | Notes |
 |------|---------|-------|
-| xUnit 2.9.2 | Test framework | All test projects |
+| xUnit 2.9.3 | Test framework | All test projects |
 | Akka.Hosting.TestKit | Actor testing | For actor-based specs |
-| FsCheck 2.16.6 | Property-based testing | Codec fuzzing |
-| FluentAssertions 6.12.1 | Assertions | |
-| TestContainers 4.1.0 | Container-based E2E tests | EMQX, NanoMQ brokers |
-| Coverlet 6.0.3 | Code coverage collection | XPlat format in CI |
+| FsCheck 2.16.6 | Property-based testing | Codec fuzzing (FsCheck 3.x not compatible without API migration) |
+| FluentAssertions 8.8.0 | Assertions | |
+| TestContainers 4.10.0 | Container-based E2E tests | EMQX, NanoMQ brokers |
+| Coverlet 8.0.0 | Code coverage collection | XPlat format in CI |
 
 ### Running Tests
 
@@ -45,7 +45,7 @@ dotnet test tests/TurboMqtt.Container.Tests/
 
 | Tool | Purpose |
 |------|---------|
-| BenchmarkDotNet 0.14.0 | Performance measurement |
+| BenchmarkDotNet 0.15.8 | Performance measurement |
 | `start-emqx.ps1` | Start EMQX Docker container for E2E benchmarks |
 | `stop-eqmx.ps1` | Stop EMQX container |
 

--- a/src/TurboMqtt/Protocol/MqttPacketSizeEstimator.cs
+++ b/src/TurboMqtt/Protocol/MqttPacketSizeEstimator.cs
@@ -532,8 +532,8 @@ internal static class MqttPacketSizeEstimator
     /// </remarks>
     public static int GetPacketLengthHeaderSize(int packetBodyLength)
     {
-        // remove 1 bytes for the fixed header, which isn't included in the length
-        return (packetBodyLength - 1) switch
+        // MQTT variable-length encoding: 1 byte for 0-127, 2 bytes for 128-16383, etc.
+        return packetBodyLength switch
         {
             < 128 => 1,
             < 16384 => 2,

--- a/src/TurboMqtt/Protocol/MqttPacketSizeEstimator.cs
+++ b/src/TurboMqtt/Protocol/MqttPacketSizeEstimator.cs
@@ -526,9 +526,8 @@ internal static class MqttPacketSizeEstimator
     ///  Helper method to calculate the length of the Variable Byte Integer for MQTT packet lengths
     /// </summary>
     /// <remarks>
-    /// Packets in MQTT can have a length header between 1-4 bytes long.
-    ///
-    /// We subtract 2 bytes from the packet body length to account for the fixed length header.
+    /// MQTT variable-length encoding uses 1-4 bytes depending on the packet body length:
+    /// 1 byte for 0-127, 2 bytes for 128-16383, 3 bytes for 16384-2097151, 4 bytes for larger.
     /// </remarks>
     public static int GetPacketLengthHeaderSize(int packetBodyLength)
     {

--- a/tests/TurboMqtt.Tests/IO/Tcp/TcpTransportActorSpecs.cs
+++ b/tests/TurboMqtt.Tests/IO/Tcp/TcpTransportActorSpecs.cs
@@ -353,7 +353,7 @@ public class TcpTransportActorSpecs : TestKit
         await ExpectTerminatedAsync(actor, TimeSpan.FromSeconds(10));
 
         // Verify data was written to the stream before shutdown
-        provider.Stream.TotalBytesWritten.Should().BeGreaterOrEqualTo(data.Length);
+        provider.Stream.TotalBytesWritten.Should().BeGreaterThanOrEqualTo(data.Length);
     }
 
     #endregion

--- a/tests/TurboMqtt.Tests/PacketGeneratorSmokeTests.cs
+++ b/tests/TurboMqtt.Tests/PacketGeneratorSmokeTests.cs
@@ -1,0 +1,72 @@
+// -----------------------------------------------------------------------
+// <copyright file="PacketGeneratorSmokeTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2024 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using FsCheck;
+using TurboMqtt.PacketTypes;
+
+namespace TurboMqtt.Tests;
+
+/// <summary>
+/// Smoke tests that verify every MQTT 3.1.1 packet generator compiles and
+/// produces non-null packets when sampled. Satisfies Task 2.1 Done-when criterion:
+/// "All generators compile and produce non-null packets when sampled".
+/// </summary>
+public class PacketGeneratorSmokeTests
+{
+    [Fact]
+    public void AllIndividualGeneratorsShouldProduceNonNullPackets()
+    {
+        var arbitraries = new (string name, FsCheck.Arbitrary<MqttPacket> arb)[]
+        {
+            ("Connect",     PacketGenerators.ConnectPacketArb()),
+            ("ConnAck",     PacketGenerators.ConnAckPacketArb()),
+            ("Publish",     PacketGenerators.PublishPacketArb()),
+            ("PubAck",      PacketGenerators.PubAckPacketArb()),
+            ("PubRec",      PacketGenerators.PubRecPacketArb()),
+            ("PubRel",      PacketGenerators.PubRelPacketArb()),
+            ("PubComp",     PacketGenerators.PubCompPacketArb()),
+            ("Subscribe",   PacketGenerators.SubscribePacketArb()),
+            ("SubAck",      PacketGenerators.SubAckPacketArb()),
+            ("Unsubscribe", PacketGenerators.UnsubscribePacketArb()),
+            ("UnsubAck",    PacketGenerators.UnsubAckPacketArb()),
+            ("PingReq",     PacketGenerators.PingReqPacketArb()),
+            ("PingResp",    PacketGenerators.PingRespPacketArb()),
+            ("Disconnect",  PacketGenerators.DisconnectPacketArb()),
+        };
+
+        foreach (var (name, arb) in arbitraries)
+        {
+            var sample = arb.Generator.Sample(10, 1).ToList();
+            var packet = Assert.Single(sample);
+            Assert.NotNull(packet);
+        }
+    }
+
+    [Fact]
+    public void PacketArbShouldCoverAllFourteenPacketTypes()
+    {
+        var packetArb = PacketGenerators.PacketArb();
+
+        // Sample enough packets to cover all 14 types with high probability.
+        var samples = packetArb.Generator.Sample(10, 200).ToList();
+        var types = samples.Select(p => p.PacketType).Distinct().ToHashSet();
+
+        types.Should().Contain(MqttPacketType.Connect);
+        types.Should().Contain(MqttPacketType.ConnAck);
+        types.Should().Contain(MqttPacketType.Publish);
+        types.Should().Contain(MqttPacketType.PubAck);
+        types.Should().Contain(MqttPacketType.PubRec);
+        types.Should().Contain(MqttPacketType.PubRel);
+        types.Should().Contain(MqttPacketType.PubComp);
+        types.Should().Contain(MqttPacketType.Subscribe);
+        types.Should().Contain(MqttPacketType.SubAck);
+        types.Should().Contain(MqttPacketType.Unsubscribe);
+        types.Should().Contain(MqttPacketType.UnsubAck);
+        types.Should().Contain(MqttPacketType.PingReq);
+        types.Should().Contain(MqttPacketType.PingResp);
+        types.Should().Contain(MqttPacketType.Disconnect);
+    }
+}

--- a/tests/TurboMqtt.Tests/PacketGenerators.cs
+++ b/tests/TurboMqtt.Tests/PacketGenerators.cs
@@ -39,21 +39,50 @@ public class PacketGenerators
 
     public static Arbitrary<MqttPacket> ConnectPacketArb()
     {
-        return (from protocolVersion in Gen.Constant(MqttProtocolVersion.V3_1_1)
-            from clientId in
-                Arb.Generate<string>()
-                    .Where(s => !string.IsNullOrWhiteSpace(s) && s.Length > 0 && MqttClientIdValidator.ValidateClientId(s).IsValid) // ensure clientId is not null or whitespace
+        var validWillTopic = Arb.Generate<string>()
+            .Where(s => !string.IsNullOrWhiteSpace(s) && s.Length > 0 && MqttTopicValidator.ValidatePublishTopic(s).IsValid);
+
+        var willPayloadGen = from length in Gen.Choose(0, 128)
+                             from bytes in Gen.ArrayOf(length, Arb.Generate<byte>())
+                             select new ReadOnlyMemory<byte>(bytes);
+
+        // Per MQTT 3.1.1 §1.5.3: U+0000 is forbidden in UTF-8 encoded strings
+        var validCredential = Arb.Generate<string>()
+            .Where(s => s != null && s.Length > 0 && !s.Contains('\0'));
+
+        return (
+            from clientId in Arb.Generate<string>()
+                .Where(s => !string.IsNullOrWhiteSpace(s) && s.Length > 0 && MqttClientIdValidator.ValidateClientId(s).IsValid)
             from cleanSession in Arb.Generate<bool>()
             from keepAlive in Arb.Generate<ushort>()
-            select (MqttPacket)new ConnectPacket(protocolVersion)
+            from hasWill in Arb.Generate<bool>()
+            from willTopic in hasWill ? validWillTopic : Gen.Constant(string.Empty)
+            from willPayload in hasWill ? willPayloadGen : Gen.Constant(ReadOnlyMemory<byte>.Empty)
+            from willQos in hasWill ? Arb.Generate<QualityOfService>() : Gen.Constant(QualityOfService.AtMostOnce)
+            from willRetain in hasWill ? Arb.Generate<bool>() : Gen.Constant(false)
+            from hasUsername in Arb.Generate<bool>()
+            from username in hasUsername ? validCredential : Gen.Constant(string.Empty)
+            // Password requires username per [MQTT-3.1.2-22]
+            from hasPassword in hasUsername ? Arb.Generate<bool>() : Gen.Constant(false)
+            from password in hasPassword ? validCredential : Gen.Constant(string.Empty)
+            select (MqttPacket)new ConnectPacket(MqttProtocolVersion.V3_1_1)
             {
                 ClientId = clientId,
-                ConnectFlags = new ConnectFlags()
+                KeepAliveSeconds = keepAlive,
+                Will = hasWill ? new MqttLastWill(willTopic, willPayload) : null,
+                UserName = hasUsername ? username : null,
+                Password = hasPassword ? password : null,
+                Flags = new ConnectFlags
                 {
-                    CleanSession = cleanSession
-                },
-                KeepAliveSeconds = keepAlive
-            }).ToArbitrary();
+                    CleanSession = cleanSession,
+                    WillFlag = hasWill,
+                    WillQoS = hasWill ? willQos : QualityOfService.AtMostOnce,
+                    WillRetain = hasWill && willRetain,
+                    UsernameFlag = hasUsername,
+                    PasswordFlag = hasPassword
+                }
+            }
+        ).ToArbitrary();
     }
 
     public static Arbitrary<MqttPacket> PublishPacketArb()
@@ -267,22 +296,22 @@ public class PacketGenerators
 
     public static Arbitrary<ReadOnlyMemory<byte>[]> FragmentedPackets(Arbitrary<MqttPacket> packetArb)
     {
-        // need help here
         var serializedPackets = packetArb.Generator.Select(packet =>
         {
             var estimatedSize = MqttPacketSizeEstimator.EstimateMqtt3PacketSize(packet);
-            
             Memory<byte> bytes = new byte[estimatedSize.TotalSize];
-            var serializedPacket = Mqtt311Encoder.EncodePacket(packet, ref bytes, estimatedSize);
-
-            return (bytes, estimatedSize);
+            Mqtt311Encoder.EncodePacket(packet, ref bytes, estimatedSize);
+            return bytes;
         });
-        
-        return (from d in serializedPackets
-            from fragmentCount in Gen.Choose(1, 10)
-            from sizes in Gen.ArrayOf(fragmentCount, Gen.Choose(1, d.bytes.Length / fragmentCount + 1))
-            where sizes.Sum() == d.bytes.Length
-            select CreateFragments(d.bytes, sizes)).ToArbitrary();
+
+        return (from bytes in serializedPackets
+            from fragmentCount in Gen.Choose(1, Math.Min(10, bytes.Length))
+            // Generate cut points in [1, bytes.Length-1]; sort+deduplicate to guarantee valid non-empty fragments
+            from cuts in Gen.ArrayOf(fragmentCount - 1, Gen.Choose(1, Math.Max(1, bytes.Length - 1)))
+            let boundaries = new[] { 0 }.Concat(cuts.Distinct().OrderBy(x => x)).Append(bytes.Length).ToArray()
+            let sizes = Enumerable.Range(0, boundaries.Length - 1)
+                                  .Select(i => boundaries[i + 1] - boundaries[i]).ToArray()
+            select CreateFragments(bytes, sizes)).ToArbitrary();
     }
     
     private static ReadOnlyMemory<byte>[] CreateFragments(in ReadOnlyMemory<byte> source, int[] sizes)

--- a/tests/TurboMqtt.Tests/PacketGenerators.cs
+++ b/tests/TurboMqtt.Tests/PacketGenerators.cs
@@ -95,11 +95,11 @@ public class PacketGenerators
                     .Where(s => !string.IsNullOrWhiteSpace(s) && s.Length > 0 && MqttTopicValidator.ValidatePublishTopic(s).IsValid) // ensure topicName is not null or whitespace
             from payloadLength in Gen.Choose(0, 32 * 1024) // You can adjust the max size as needed
             from bytes in Gen.ArrayOf(payloadLength, Arb.Generate<byte>())
-            from packetId in Arb.Generate<ushort>()
+            from packetId in Gen.Choose(1, 65535)
             select (MqttPacket)new PublishPacket(qos, duplicate, retainRequested, topicName)
             {
                 Payload = new ReadOnlyMemory<byte>(bytes),
-                PacketId = packetId
+                PacketId = (NonZeroUInt16)(ushort)packetId
             }).ToArbitrary();
     }
     

--- a/tests/TurboMqtt.Tests/PacketGenerators.cs
+++ b/tests/TurboMqtt.Tests/PacketGenerators.cs
@@ -74,14 +74,197 @@ public class PacketGenerators
             }).ToArbitrary();
     }
     
+    /// <summary>
+    /// Generates valid MQTT 3.1.1 CONNACK packets.
+    /// Valid return codes per OASIS MQTT 3.1.1 §3.2.2.3: 0x00-0x05.
+    /// Per spec, SessionPresent MUST be 0 when return code != 0 (not accepted).
+    /// </summary>
+    public static Arbitrary<MqttPacket> ConnAckPacketArb()
+    {
+        var mqtt311ReturnCodes = new ConnAckReasonCode[]
+        {
+            ConnAckReasonCode.Success,        // 0x00: Connection Accepted
+            (ConnAckReasonCode)0x01,          // Connection Refused - unacceptable protocol version
+            (ConnAckReasonCode)0x02,          // Connection Refused - identifier rejected
+            (ConnAckReasonCode)0x03,          // Connection Refused - server unavailable
+            (ConnAckReasonCode)0x04,          // Connection Refused - bad user name or password
+            (ConnAckReasonCode)0x05,          // Connection Refused - not authorized
+        };
+
+        return (from reasonCode in Gen.Elements(mqtt311ReturnCodes)
+                // Per MQTT 3.1.1 spec §3.2.2.2, SessionPresent must be 0 if return code != Success
+                from sessionPresent in reasonCode == ConnAckReasonCode.Success
+                    ? Arb.Generate<bool>()
+                    : Gen.Constant(false)
+                select (MqttPacket)new ConnAckPacket
+                {
+                    SessionPresent = sessionPresent,
+                    ReasonCode = reasonCode
+                }).ToArbitrary();
+    }
+
+    /// <summary>Generates valid MQTT 3.1.1 PUBACK packets with randomized packet identifiers.</summary>
+    public static Arbitrary<MqttPacket> PubAckPacketArb()
+    {
+        return (from packetId in Gen.Choose(1, 65535)
+                select (MqttPacket)new PubAckPacket
+                {
+                    PacketId = (NonZeroUInt16)(ushort)packetId
+                }).ToArbitrary();
+    }
+
+    /// <summary>Generates valid MQTT 3.1.1 PUBREC packets with randomized packet identifiers.</summary>
+    public static Arbitrary<MqttPacket> PubRecPacketArb()
+    {
+        return (from packetId in Gen.Choose(1, 65535)
+                select (MqttPacket)new PubRecPacket
+                {
+                    PacketId = (NonZeroUInt16)(ushort)packetId
+                }).ToArbitrary();
+    }
+
+    /// <summary>Generates valid MQTT 3.1.1 PUBREL packets with randomized packet identifiers.</summary>
+    public static Arbitrary<MqttPacket> PubRelPacketArb()
+    {
+        return (from packetId in Gen.Choose(1, 65535)
+                select (MqttPacket)new PubRelPacket
+                {
+                    PacketId = (NonZeroUInt16)(ushort)packetId
+                }).ToArbitrary();
+    }
+
+    /// <summary>Generates valid MQTT 3.1.1 PUBCOMP packets with randomized packet identifiers.</summary>
+    public static Arbitrary<MqttPacket> PubCompPacketArb()
+    {
+        return (from packetId in Gen.Choose(1, 65535)
+                select (MqttPacket)new PubCompPacket
+                {
+                    PacketId = (NonZeroUInt16)(ushort)packetId
+                }).ToArbitrary();
+    }
+
+    /// <summary>
+    /// Generates valid MQTT 3.1.1 SUBSCRIBE packets with 1-5 valid topic filters.
+    /// SubscriptionIdentifier is set to 1 (not encoded in MQTT 3.1.1).
+    /// </summary>
+    public static Arbitrary<MqttPacket> SubscribePacketArb()
+    {
+        var validSubscribeTopic = Arb.Generate<string>()
+            .Where(s => !string.IsNullOrWhiteSpace(s) && s.Length > 0
+                        && MqttTopicValidator.ValidateSubscribeTopic(s).IsValid);
+
+        var topicSubscriptionGen = from topic in validSubscribeTopic
+                                   from qos in Arb.Generate<QualityOfService>()
+                                   select new TopicSubscription(topic)
+                                   {
+                                       Options = new SubscriptionOptions { QoS = qos }
+                                   };
+
+        return (from packetId in Gen.Choose(1, 65535)
+                from topicCount in Gen.Choose(1, 5)
+                from topics in Gen.ArrayOf(topicCount, topicSubscriptionGen)
+                select (MqttPacket)new SubscribePacket
+                {
+                    PacketId = (NonZeroUInt16)(ushort)packetId,
+                    SubscriptionIdentifier = new NonZeroUInt16(1), // not encoded in MQTT 3.1.1
+                    Topics = topics
+                }).ToArbitrary();
+    }
+
+    /// <summary>
+    /// Generates valid MQTT 3.1.1 SUBACK packets with 1-5 reason codes.
+    /// Only MQTT 3.1.1 valid codes: GrantedQoS0, GrantedQoS1, GrantedQoS2, UnspecifiedError.
+    /// </summary>
+    public static Arbitrary<MqttPacket> SubAckPacketArb()
+    {
+        var mqtt311SubAckCodes = new MqttSubscribeReasonCode[]
+        {
+            MqttSubscribeReasonCode.GrantedQoS0,
+            MqttSubscribeReasonCode.GrantedQoS1,
+            MqttSubscribeReasonCode.GrantedQoS2,
+            MqttSubscribeReasonCode.UnspecifiedError
+        };
+
+        return (from packetId in Gen.Choose(1, 65535)
+                from codeCount in Gen.Choose(1, 5)
+                from codes in Gen.ArrayOf(codeCount, Gen.Elements(mqtt311SubAckCodes))
+                select (MqttPacket)new SubAckPacket
+                {
+                    PacketId = (NonZeroUInt16)(ushort)packetId,
+                    ReasonCodes = codes
+                }).ToArbitrary();
+    }
+
+    /// <summary>
+    /// Generates valid MQTT 3.1.1 UNSUBSCRIBE packets with 1-5 valid topic filters.
+    /// </summary>
+    public static Arbitrary<MqttPacket> UnsubscribePacketArb()
+    {
+        var validSubscribeTopic = Arb.Generate<string>()
+            .Where(s => !string.IsNullOrWhiteSpace(s) && s.Length > 0
+                        && MqttTopicValidator.ValidateSubscribeTopic(s).IsValid);
+
+        return (from packetId in Gen.Choose(1, 65535)
+                from topicCount in Gen.Choose(1, 5)
+                from topics in Gen.ArrayOf(topicCount, validSubscribeTopic)
+                select (MqttPacket)new UnsubscribePacket
+                {
+                    PacketId = (NonZeroUInt16)(ushort)packetId,
+                    Topics = topics
+                }).ToArbitrary();
+    }
+
+    /// <summary>
+    /// Generates valid MQTT 3.1.1 UNSUBACK packets.
+    /// In MQTT 3.1.1 this packet contains only the packet identifier.
+    /// </summary>
+    public static Arbitrary<MqttPacket> UnsubAckPacketArb()
+    {
+        return (from packetId in Gen.Choose(1, 65535)
+                select (MqttPacket)new UnsubAckPacket
+                {
+                    PacketId = (NonZeroUInt16)(ushort)packetId
+                }).ToArbitrary();
+    }
+
+    /// <summary>Generates the PINGREQ singleton. No variable fields in MQTT 3.1.1.</summary>
+    public static Arbitrary<MqttPacket> PingReqPacketArb()
+        => Gen.Constant((MqttPacket)PingReqPacket.Instance).ToArbitrary();
+
+    /// <summary>Generates the PINGRESP singleton. No variable fields in MQTT 3.1.1.</summary>
+    public static Arbitrary<MqttPacket> PingRespPacketArb()
+        => Gen.Constant((MqttPacket)PingRespPacket.Instance).ToArbitrary();
+
+    /// <summary>
+    /// Generates MQTT 3.1.1 DISCONNECT packets.
+    /// In MQTT 3.1.1 this is a fixed-header-only packet with no variable content.
+    /// </summary>
+    public static Arbitrary<MqttPacket> DisconnectPacketArb()
+        => Gen.Constant((MqttPacket)new DisconnectPacket()).ToArbitrary();
+
+    /// <summary>
+    /// Combined generator using all 14 MQTT 3.1.1 packet types via Gen.OneOf.
+    /// </summary>
     public static Arbitrary<MqttPacket> PacketArb()
     {
         return Gen.OneOf(
             ConnectPacketArb().Generator,
-            PublishPacketArb().Generator
+            ConnAckPacketArb().Generator,
+            PublishPacketArb().Generator,
+            PubAckPacketArb().Generator,
+            PubRecPacketArb().Generator,
+            PubRelPacketArb().Generator,
+            PubCompPacketArb().Generator,
+            SubscribePacketArb().Generator,
+            SubAckPacketArb().Generator,
+            UnsubscribePacketArb().Generator,
+            UnsubAckPacketArb().Generator,
+            PingReqPacketArb().Generator,
+            PingRespPacketArb().Generator,
+            DisconnectPacketArb().Generator
         ).ToArbitrary();
     }
-    
+
     public static Arbitrary<ReadOnlyMemory<byte>[]> FragmentedPackets(Arbitrary<MqttPacket> packetArb)
     {
         // need help here


### PR DESCRIPTION
## Summary

- **Task 1.6**: Update all test and tooling packages to latest stable (FluentAssertions 8.8.0, xunit 2.9.3, Microsoft.NET.Test.Sdk 18.0.1, Testcontainers 4.10.0, coverlet 8.0.0, etc.)
- **Task 1.7**: Update PROJECT_CONTEXT.md and TOOLING.md to reflect Phase 1 changes; update copyright year
- **Task 2.1**: Add FsCheck generators for all 14 MQTT 3.1.1 packet types with smoke tests
- **Task 2.2**: Expand ConnectPacketArb with Will, Username, Password fields; fix `GetPacketLengthHeaderSize` off-by-one bug at VLI boundaries (128, 16384, 2097152); rewrite `FragmentedPackets` from rejection sampling to deterministic cut-point partitioning
- **After-action fixes**: Fix pre-existing `PublishPacketArb` crash when generating PacketId=0; fix stale XML doc comment; use dynamic MSBuild copyright year

## Bugs Fixed

- **`GetPacketLengthHeaderSize` off-by-one** (production bug): `(packetBodyLength - 1) switch` returned wrong byte count at VLI boundaries, causing buffer overflow during CONNECT packet encoding with payloads near 128/16384/2097152 bytes
- **`PublishPacketArb` PacketId=0** (latent test crash): `Arb.Generate<ushort>()` could produce 0, crashing `NonZeroUInt16` constructor — changed to `Gen.Choose(1, 65535)` matching all other generators

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/TurboMqtt.Tests/ -c Release` — 239 passed, 0 failed, 0 skipped
- [ ] CI PR validation passes (Linux + Windows)