### PR TITLE
Prevent .ralph/ flight recorder from being committed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,10 @@ All code must compile with zero warnings (`TreatWarningsAsErrors` is on).
 - Akka.NET actors use `ReceiveActor` or `UntypedActor` patterns; hosting via `Akka.Hosting`
 - Internal types exposed to test projects via `InternalsVisibleTo` in `Properties/Friends.cs`
 
+## Commit Rules
+
+- **NEVER `git add` the `.ralph/` directory or anything inside it.** Flight recorder logs are ephemeral and local-only. They must not appear in any commit.
+
 ## Key Architectural Rules
 
 - **Akka.NET is the concurrency model.** Do not introduce raw `Task.Run`, `Thread`, or manual synchronization unless there is no actor-based alternative.

--- a/ralph.sh
+++ b/ralph.sh
@@ -389,6 +389,7 @@ for ((i=1; i<=ITERATIONS; i++)); do
 
 8) If verification passes:
    - Commit to the current feature branch with a descriptive message
+   - NEVER 'git add' the .ralph/ directory or any files inside it — flight recorder logs are local-only
    - Update $PLAN_FILE checkboxes in the SAME commit
    - Update TOOLING.md if you used or discovered a new tool/resource
 


### PR DESCRIPTION
## Summary
- Added explicit instruction in `ralph.sh` telling agents to never `git add` the `.ralph/` directory
- Added hard commit rule in `CLAUDE.md` banning `.ralph/` from any commit

## Context
The `.ralph/` flight recorder logs kept getting committed to feature branches during RALPH runs despite being in `.gitignore`. The root cause was that `ralph.sh` told agents to write iter logs then commit, and agents were staging everything including `.ralph/`. Once tracked, `.gitignore` is ineffective.

The `.gitignore` entry already exists — these changes add defense-in-depth at the agent instruction level.

## Test plan
- [ ] Run a RALPH iteration and verify `.ralph/` files are not included in the commit