### PR TITLE
Add remaining spec compliance tasks and validations (Tasks 6.5-6.10)

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -562,6 +562,50 @@ Done when:
 - [x] API review findings documented in `docs/release/api-review.md`
 - [x] Issue #354 closed
 
+### Task 6.9: Make internal-only types internal (API review follow-ups F-3, F-5, F-6)
+
+**Source:** `docs/release/api-review.md` findings F-3, F-5, F-6 (Run 20260221-151320, iter-03)
+**Surface area:** domain
+**Verification:** L1
+
+Three public types were identified as incorrectly public during the API review:
+- `MqttClient` (F-3) — concrete implementation; callers use `IMqttClient`
+- `PublishingProtocol.SetReceiveMaximum` (F-5) — internal actor message
+- `UShortCounter` (F-6) — internal utility
+
+All three are covered by `InternalsVisibleTo("TurboMqtt.Tests")` so tests still compile.
+
+Key files:
+- `src/TurboMqtt/Client/IMqttClient.cs` (`MqttClient`)
+- `src/TurboMqtt/Protocol/Pub/PublishingProtocol.cs` (`SetReceiveMaximum`)
+- `src/TurboMqtt/Utility/UShortCounter.cs` (`UShortCounter`)
+
+Done when:
+- [x] `MqttClient` changed from `public sealed class` to `internal sealed class`
+- [x] `PublishingProtocol.SetReceiveMaximum` changed from `public sealed class` to `internal sealed class`
+- [x] `UShortCounter` changed from `public sealed class` to `internal sealed class`
+- [x] Builds with zero warnings
+- [x] All existing tests pass
+
+### Task 6.10: Rename TurbotMqttHostingExtensions to TurboMqttHostingExtensions (F-1)
+
+**Source:** `docs/release/api-review.md` finding F-1 (Run 20260221-151320, iter-03)
+**Surface area:** cross-cutting
+**Verification:** L1
+
+`TurbotMqttHostingExtensions` has a typo (`Turbot` instead of `Turbo`) in both the class name
+and the filename. Must be fixed before v1.0 as this is the last opportunity before SemVer locks it.
+
+Key files:
+- `src/TurboMqtt/TurbotMqttHostingExtensions.cs`
+
+Done when:
+- [ ] Class renamed from `TurbotMqttHostingExtensions` to `TurboMqttHostingExtensions`
+- [ ] File renamed from `TurbotMqttHostingExtensions.cs` to `TurboMqttHostingExtensions.cs`
+- [ ] All references to the old class name updated
+- [ ] Builds with zero warnings
+- [ ] All existing tests pass
+
 ---
 
 ## Dependency Graph

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -459,6 +459,92 @@ Done when:
 - [x] Criteria covers: protocol scope, API stability promise, perf bar, test pass rate
 - [x] Issue #353 closed
 
+### Task 6.5: Remove duplicate ConnectPacket.ConnectFlags property
+
+**PRD:** https://github.com/petabridge/TurboMqtt/issues/348
+**Surface area:** domain
+**Verification:** L1
+
+**BREAKING CHANGE.** `ConnectPacket` has two properties of the same type: `Flags`
+(used by encoders/decoders) and `ConnectFlags` (used by client code). Tests already
+exclude `ConnectFlags` from equality comparisons with a comment marking it as a
+duplicate. Remove `ConnectFlags` and update all call sites to use `Flags`.
+
+Key files:
+- `src/TurboMqtt/PacketTypes/ConnectPacket.cs`
+- `src/TurboMqtt/Client/IMqttClient.cs` (sets `ConnectFlags`)
+
+Done when:
+- [ ] `ConnectPacket.ConnectFlags` property removed
+- [ ] All references updated to use `Flags`
+- [ ] The `.Excluding(x => x.ConnectFlags)` exclusion in roundtrip tests removed
+- [ ] Roundtrip property tests pass with the unified `Flags` property
+- [ ] Builds with zero warnings
+- [ ] All existing tests pass
+
+### Task 6.6: Add ConnectFlags reserved bit and WillQoS validation
+
+**PRD:** https://github.com/petabridge/TurboMqtt/issues/344 and https://github.com/petabridge/TurboMqtt/issues/345
+**Surface area:** domain
+**Verification:** L1
+
+`ConnectFlags.Decode` does not validate: (a) that bit 0 (reserved) must be 0
+[MQTT-3.1.2-3]; (b) that WillQoS ≤ 2 when WillFlag is set [MQTT-3.1.2-14].
+Malformed packets are silently accepted instead of being rejected.
+
+Key file: `src/TurboMqtt/PacketTypes/ConnectPacket.cs`, `ConnectFlags.Decode` method (line ~141).
+
+Done when:
+- [ ] Decode throws `ArgumentOutOfRangeException` when bit 0 is 1, with message referencing MQTT-3.1.2-3
+- [ ] Decode throws `ArgumentOutOfRangeException` when WillFlag=true and WillQoS > 2, with message referencing MQTT-3.1.2-14
+- [ ] Deterministic unit tests cover both rejection cases
+- [ ] Existing decode tests still pass
+- [ ] Builds with zero warnings
+- [ ] All existing tests pass
+
+### Task 6.7: Validate fixed header reserved bits for SUBSCRIBE/UNSUBSCRIBE/PUBREL
+
+**PRD:** https://github.com/petabridge/TurboMqtt/issues/346
+**Surface area:** domain
+**Verification:** L1
+
+The decoder extracts only the upper nibble (packet type) from the first fixed
+header byte and ignores the lower nibble entirely. Per MQTT-2.2.2, SUBSCRIBE,
+UNSUBSCRIBE, and PUBREL must have lower nibble = 0x2. Packets with wrong reserved
+bits are silently accepted.
+
+Key file: `src/TurboMqtt/Protocol/Mqtt311Decoder.cs` (line ~60 where `packetType` is extracted).
+Also check `Mqtt5Decoder.cs` if it has its own first-byte parsing.
+
+Done when:
+- [ ] Decoder validates lower nibble = 0x2 for SUBSCRIBE (expected first byte 0x82)
+- [ ] Decoder validates lower nibble = 0x2 for UNSUBSCRIBE (expected first byte 0xA2)
+- [ ] Decoder validates lower nibble = 0x2 for PUBREL (expected first byte 0x62)
+- [ ] Invalid reserved bits cause a decode error (not silent acceptance)
+- [ ] Deterministic tests verify rejection for each of the three packet types
+- [ ] Builds with zero warnings
+- [ ] All existing tests pass
+
+### Task 6.8: Add buffer size validation to Mqtt311EncoderOptimized
+
+**PRD:** https://github.com/petabridge/TurboMqtt/issues/350
+**Surface area:** domain
+**Verification:** L1
+
+`Mqtt311EncoderOptimized.EncodePacket` has no buffer size guard before writing
+packet data, risking `IndexOutOfRangeException` on undersized buffers.
+`Mqtt311Encoder.EncodePacket` has the guard (`if (buffer.Length < estimatedSize.TotalSize) throw`).
+The optimized encoder should have the same protection.
+
+Key file: `src/TurboMqtt/Protocol/Mqtt311EncoderOptimized.cs` (line ~40, `EncodePacket` method).
+
+Done when:
+- [ ] `EncodePacket` validates `buffer.Length >= estimatedSize.TotalSize` before writing
+- [ ] Throws `ArgumentException` with a descriptive message on undersized buffer
+- [ ] Test verifies the exception is thrown when an undersized buffer is passed
+- [ ] Builds with zero warnings
+- [ ] All existing tests pass
+
 ### Task 6.4: API stability review before 1.0 release
 
 **PRD:** https://github.com/petabridge/TurboMqtt/issues/354
@@ -506,5 +592,9 @@ Phase 6 (Release Preparation) → starts after Phase 5
 ├── Task 6.1 (Release test gate)             → no dependencies within phase
 ├── Task 6.2 (Production benchmarks)         → depends on all code changes (Phase 4+5)
 ├── Task 6.3 (Release criteria)              → requires human decision
-└── Task 6.4 (API review)                    → depends on Tasks 4.6, 4.7 (breaking changes)
+├── Task 6.5 (Remove duplicate ConnectFlags) → no dependencies, BREAKING CHANGE
+├── Task 6.6 (ConnectFlags validation)       → no dependencies
+├── Task 6.7 (Fixed header reserved bits)    → no dependencies
+├── Task 6.8 (Encoder buffer validation)     → no dependencies
+└── Task 6.4 (API review)                    → depends on Tasks 4.6, 4.7, 6.5 (breaking changes)
 ```

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -495,12 +495,12 @@ Malformed packets are silently accepted instead of being rejected.
 Key file: `src/TurboMqtt/PacketTypes/ConnectPacket.cs`, `ConnectFlags.Decode` method (line ~141).
 
 Done when:
-- [ ] Decode throws `ArgumentOutOfRangeException` when bit 0 is 1, with message referencing MQTT-3.1.2-3
-- [ ] Decode throws `ArgumentOutOfRangeException` when WillFlag=true and WillQoS > 2, with message referencing MQTT-3.1.2-14
-- [ ] Deterministic unit tests cover both rejection cases
-- [ ] Existing decode tests still pass
-- [ ] Builds with zero warnings
-- [ ] All existing tests pass
+- [x] Decode throws `ArgumentOutOfRangeException` when bit 0 is 1, with message referencing MQTT-3.1.2-3
+- [x] Decode throws `ArgumentOutOfRangeException` when WillFlag=true and WillQoS > 2, with message referencing MQTT-3.1.2-14
+- [x] Deterministic unit tests cover both rejection cases
+- [x] Existing decode tests still pass
+- [x] Builds with zero warnings
+- [x] All existing tests pass
 
 ### Task 6.7: Validate fixed header reserved bits for SUBSCRIBE/UNSUBSCRIBE/PUBREL
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -517,13 +517,13 @@ Key file: `src/TurboMqtt/Protocol/Mqtt311Decoder.cs` (line ~60 where `packetType
 Also check `Mqtt5Decoder.cs` if it has its own first-byte parsing.
 
 Done when:
-- [ ] Decoder validates lower nibble = 0x2 for SUBSCRIBE (expected first byte 0x82)
-- [ ] Decoder validates lower nibble = 0x2 for UNSUBSCRIBE (expected first byte 0xA2)
-- [ ] Decoder validates lower nibble = 0x2 for PUBREL (expected first byte 0x62)
-- [ ] Invalid reserved bits cause a decode error (not silent acceptance)
-- [ ] Deterministic tests verify rejection for each of the three packet types
-- [ ] Builds with zero warnings
-- [ ] All existing tests pass
+- [x] Decoder validates lower nibble = 0x2 for SUBSCRIBE (expected first byte 0x82)
+- [x] Decoder validates lower nibble = 0x2 for UNSUBSCRIBE (expected first byte 0xA2)
+- [x] Decoder validates lower nibble = 0x2 for PUBREL (expected first byte 0x62)
+- [x] Invalid reserved bits cause a decode error (not silent acceptance)
+- [x] Deterministic tests verify rejection for each of the three packet types
+- [x] Builds with zero warnings
+- [x] All existing tests pass
 
 ### Task 6.8: Add buffer size validation to Mqtt311EncoderOptimized
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -556,11 +556,11 @@ Done when:
 channel-based consumer APIs, and all MQTT 5.0 additions.
 
 Done when:
-- [ ] Public API surface enumerated with `dotnet public-api` or equivalent
-- [ ] API reviewed for: naming consistency, extend-only compatibility, correct use of `internal` vs `public`, `IAsyncDisposable` consistency
-- [ ] Breaking changes from Tasks 4.6 and 4.7 reviewed for downstream impact
-- [ ] API review findings documented in `docs/release/api-review.md`
-- [ ] Issue #354 closed
+- [x] Public API surface enumerated with `dotnet public-api` or equivalent
+- [x] API reviewed for: naming consistency, extend-only compatibility, correct use of `internal` vs `public`, `IAsyncDisposable` consistency
+- [x] Breaking changes from Tasks 4.6 and 4.7 reviewed for downstream impact
+- [x] API review findings documented in `docs/release/api-review.md`
+- [x] Issue #354 closed
 
 ---
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -600,11 +600,11 @@ Key files:
 - `src/TurboMqtt/TurbotMqttHostingExtensions.cs`
 
 Done when:
-- [ ] Class renamed from `TurbotMqttHostingExtensions` to `TurboMqttHostingExtensions`
-- [ ] File renamed from `TurbotMqttHostingExtensions.cs` to `TurboMqttHostingExtensions.cs`
-- [ ] All references to the old class name updated
-- [ ] Builds with zero warnings
-- [ ] All existing tests pass
+- [x] Class renamed from `TurbotMqttHostingExtensions` to `TurboMqttHostingExtensions`
+- [x] File renamed from `TurbotMqttHostingExtensions.cs` to `TurboMqttHostingExtensions.cs`
+- [x] All references to the old class name updated
+- [x] Builds with zero warnings
+- [x] All existing tests pass
 
 ---
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -475,12 +475,12 @@ Key files:
 - `src/TurboMqtt/Client/IMqttClient.cs` (sets `ConnectFlags`)
 
 Done when:
-- [ ] `ConnectPacket.ConnectFlags` property removed
-- [ ] All references updated to use `Flags`
-- [ ] The `.Excluding(x => x.ConnectFlags)` exclusion in roundtrip tests removed
-- [ ] Roundtrip property tests pass with the unified `Flags` property
-- [ ] Builds with zero warnings
-- [ ] All existing tests pass
+- [x] `ConnectPacket.ConnectFlags` property removed
+- [x] All references updated to use `Flags`
+- [x] The `.Excluding(x => x.ConnectFlags)` exclusion in roundtrip tests removed
+- [x] Roundtrip property tests pass with the unified `Flags` property
+- [x] Builds with zero warnings
+- [x] All existing tests pass
 
 ### Task 6.6: Add ConnectFlags reserved bit and WillQoS validation
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -539,11 +539,11 @@ The optimized encoder should have the same protection.
 Key file: `src/TurboMqtt/Protocol/Mqtt311EncoderOptimized.cs` (line ~40, `EncodePacket` method).
 
 Done when:
-- [ ] `EncodePacket` validates `buffer.Length >= estimatedSize.TotalSize` before writing
-- [ ] Throws `ArgumentException` with a descriptive message on undersized buffer
-- [ ] Test verifies the exception is thrown when an undersized buffer is passed
-- [ ] Builds with zero warnings
-- [ ] All existing tests pass
+- [x] `EncodePacket` validates `buffer.Length >= estimatedSize.TotalSize` before writing
+- [x] Throws `ArgumentException` with a descriptive message on undersized buffer
+- [x] Test verifies the exception is thrown when an undersized buffer is passed
+- [x] Builds with zero warnings
+- [x] All existing tests pass
 
 ### Task 6.4: API stability review before 1.0 release
 

--- a/benchmarks/TurboMqtt.Benchmarks/Mqtt311/Mqtt311ConnectCodecBenchmarks.cs
+++ b/benchmarks/TurboMqtt.Benchmarks/Mqtt311/Mqtt311ConnectCodecBenchmarks.cs
@@ -23,7 +23,7 @@ public class Mqtt311ConnectCodecBenchmarks
         Password = "benchmark-password",
         ProtocolName = "MQTT",
         KeepAliveSeconds = 2,
-        ConnectFlags = new ConnectFlags
+        Flags = new ConnectFlags
         {
             CleanSession = true,
             WillFlag = false,

--- a/benchmarks/TurboMqtt.Benchmarks/Mqtt311/Mqtt311PacketSizeEstimatorBenchmark.cs
+++ b/benchmarks/TurboMqtt.Benchmarks/Mqtt311/Mqtt311PacketSizeEstimatorBenchmark.cs
@@ -24,7 +24,7 @@ public class Mqtt311PacketSizeEstimatorBenchmark
             UserName = "user1",
             Password = "password1",
             KeepAliveSeconds = 5,
-            ConnectFlags = new ConnectFlags()
+            Flags = new ConnectFlags()
             {
                 CleanSession = true,
                 PasswordFlag = true,

--- a/benchmarks/TurboMqtt.Benchmarks/Mqtt5/Mqtt5ConnectCodecBenchmarks.cs
+++ b/benchmarks/TurboMqtt.Benchmarks/Mqtt5/Mqtt5ConnectCodecBenchmarks.cs
@@ -23,7 +23,7 @@ public class Mqtt5ConnectCodecBenchmarks
         Password = "benchmark-password",
         ProtocolName = "MQTT",
         KeepAliveSeconds = 2,
-        ConnectFlags = new ConnectFlags
+        Flags = new ConnectFlags
         {
             CleanSession = true,
             WillFlag = false,

--- a/docs/release/api-review.md
+++ b/docs/release/api-review.md
@@ -1,0 +1,321 @@
+# TurboMqtt v1.0 API Stability Review
+
+> **Status:** Complete
+> **Owner:** Petabridge
+> **Related issue:** [#354](https://github.com/petabridge/TurboMqtt/issues/354)
+> **Last updated:** 2026-02-21
+
+This document records the pre-v1.0 public API surface review for TurboMqtt. It covers naming
+consistency, `internal` vs. `public` scoping, `IAsyncDisposable` consistency, and the breaking
+changes introduced in Tasks 4.6 and 4.7.
+
+---
+
+## 1. Public API Surface
+
+All public types in `src/TurboMqtt/` are enumerated below, grouped by namespace.
+
+### 1.1 `TurboMqtt` (root namespace)
+
+| Type | Kind | Notes |
+|------|------|-------|
+| `TurbotMqttHostingExtensions` | `static class` | ⚠️ See naming note below |
+| `MqttMessage` | `sealed record` | User-facing message DTO |
+| `QualityOfService` | `enum` | QoS 0/1/2 |
+| `MqttPacketType` | `enum` | Internal packet type codes |
+| `NonZeroUInt16` | `struct` | Validates packet IDs ≥ 1 |
+
+### 1.2 `TurboMqtt.Client`
+
+| Type | Kind | Notes |
+|------|------|-------|
+| `IMqttClient` | `interface` | Primary user-facing contract |
+| `MqttClient` | `sealed class` | Concrete impl; ⚠️ See scoping note |
+| `IMqttClientFactory` | `interface` | Factory contract |
+| `MqttClientFactory` | `sealed class` | Concrete impl; ⚠️ See scoping note |
+| `MqttClientConnectOptions` | `sealed record` | Connection configuration |
+| `LastWillAndTestament` | `sealed record` | User-facing LWT config |
+| `MqttClientTcpOptions` | `sealed record` | TCP transport options |
+| `MqttClientTlsOptions` | `sealed record` | TLS options |
+| `IMqtt5AuthHandler` | `interface` | MQTT 5.0 enhanced auth |
+
+### 1.3 `TurboMqtt.PacketTypes`
+
+| Type | Kind | Notes |
+|------|------|-------|
+| `MqttPacket` | `abstract class` | Base for all packets |
+| `MqttPacketWithId` | `abstract class` | Base for packets with packet IDs |
+| `ConnectPacket` | `sealed class` | CONNECT wire type |
+| `ConnectFlags` | `struct` | CONNECT flags byte |
+| `MqttLastWill` | `sealed class` | LWT in wire format; ⚠️ see naming note |
+| `ConnAckPacket` | `sealed class` | CONNACK |
+| `PublishPacket` | `sealed class` | PUBLISH |
+| `PubAckPacket` | `sealed class` | PUBACK |
+| `PubRecPacket` | `sealed class` | PUBREC |
+| `PubRelPacket` | `sealed class` | PUBREL |
+| `PubCompPacket` | `sealed class` | PUBCOMP |
+| `SubscribePacket` | `sealed class` | SUBSCRIBE |
+| `TopicSubscription` | `sealed class` | Single topic + options |
+| `SubscriptionOptions` | `struct` | Topic subscription options |
+| `SubAckPacket` | `sealed class` | SUBACK |
+| `UnsubscribePacket` | `sealed class` | UNSUBSCRIBE |
+| `UnsubAckPacket` | `sealed class` | UNSUBACK |
+| `DisconnectPacket` | `sealed class` | DISCONNECT |
+| `AuthPacket` | `sealed class` | AUTH (MQTT 5.0 only) |
+| `PingReqPacket` | `sealed class` | PINGREQ (singleton) |
+| `PingRespPacket` | `sealed class` | PINGRESP (singleton) |
+| `ConnAckReasonCode` | `enum : byte` | CONNACK reason codes |
+| `MqttPubAckReasonCode` | `enum : byte` | PUBACK reason codes |
+| `PubRecReasonCode` | `enum : byte` | PUBREC reason codes |
+| `PubRelReasonCode` | `enum : byte` | PUBREL reason codes |
+| `PubCompReasonCode` | `enum : byte` | PUBCOMP reason codes |
+| `MqttSubscribeReasonCode` | `enum : byte` | SUBACK reason codes |
+| `MqttUnsubscribeReasonCode` | `enum : byte` | UNSUBACK reason codes |
+| `DisconnectReasonCode` | `enum : byte` | DISCONNECT reason codes |
+| `AuthReasonCode` | `enum : byte` | AUTH reason codes (MQTT 5.0) |
+| `PayloadFormatIndicator` | `enum : byte` | Payload encoding hint |
+| `RetainHandlingOption` | `enum : byte` | Retain-on-subscribe behavior |
+
+### 1.4 `TurboMqtt.Protocol`
+
+| Type | Kind | Notes |
+|------|------|-------|
+| `IAckResponse` | `interface` | Base for all response types |
+| `IConnectResponse` | `interface` | Connect response |
+| `IDisconnectResponse` | `interface` | Disconnect response |
+| `ISubscribeResponse` | `interface` | Subscribe response |
+| `IUnsubscribeResponse` | `interface` | Unsubscribe response |
+| `AckProtocol` | `static class` | Concrete response implementations |
+| `AckProtocol.ConnectSuccess` | `sealed class` | |
+| `AckProtocol.ConnectFailure` | `sealed class` | |
+| `AckProtocol.DisconnectSuccess` | `sealed class` | Singleton |
+| `AckProtocol.SubscribeSuccess` | `sealed class` | |
+| `AckProtocol.SubscribeFailure` | `sealed class` | |
+| `AckProtocol.UnsubscribeSuccess` | `sealed class` | |
+| `AckProtocol.UnsubscribeFailure` | `sealed class` | |
+| `MqttProtocolVersion` | `enum : byte` | V3_1_1 = 4, V5_0 = 5 |
+
+### 1.5 `TurboMqtt.Protocol.Pub`
+
+| Type | Kind | Notes |
+|------|------|-------|
+| `IPublishResult` | `interface` | Result of a publish operation |
+| `PublishingStatus` | `enum` | Publishing / PubRecReceived / Completed / Failed |
+| `PublishingProtocol` | `static class` | Factory for publish results |
+| `PublishingProtocol.PublishSuccess` | `sealed class` | Singleton success |
+| `PublishingProtocol.PublishFailure` | `sealed class` | Error with reason string |
+| `PublishingProtocol.PublishCancelled` | `sealed class` | Cancelled with packet ID |
+| `PublishingProtocol.SetReceiveMaximum` | `sealed class` | Internal actor message; ⚠️ should be internal |
+
+### 1.6 `TurboMqtt.Utility`
+
+| Type | Kind | Notes |
+|------|------|-------|
+| `UShortCounter` | `sealed class` | Thread-safe ushort counter; ⚠️ should be internal |
+
+---
+
+## 2. Findings
+
+### 2.1 Naming Issues
+
+#### F-1: `TurbotMqttHostingExtensions` — typo in class and file name
+
+**Severity:** Low (pre-1.0 breaking change acceptable)
+
+The class is named `TurbotMqttHostingExtensions` (`TurbotMqtt` instead of `TurboMqtt`). The file
+is named identically. The extension method `AddTurboMqttClientFactory` is correctly named.
+
+**Recommendation:** Rename the class to `TurboMqttHostingExtensions` before v1.0. This is a
+breaking change but is the last opportunity to fix it without a major version bump.
+
+**Action required:** File a fix issue; include in v1.0 release branch.
+
+---
+
+#### F-2: `MqttLastWill` vs. `LastWillAndTestament` — dual naming for LWT
+
+**Severity:** Low
+
+Two public types represent the "Last Will and Testament" concept with different names:
+- `MqttLastWill` (in `PacketTypes`) — used inside the wire-format `ConnectPacket`
+- `LastWillAndTestament` (in `Client`) — used in `MqttClientConnectOptions`, the user-facing API
+
+The naming is intentionally layered (wire vs. user API) but can confuse callers who see both when
+inspecting packet types. `MqttLastWill` should arguably be `internal` since callers use
+`LastWillAndTestament` to configure the client, and the library handles the translation.
+
+**Recommendation:** Make `MqttLastWill` (and all other wire-format `PacketTypes`) `internal`. User
+code should only touch `Client` namespace types and `MqttMessage`. For v1.0 this is a **breaking
+change** — defer to v2.0 unless the decision is made now.
+
+**Decision for v1.0:** Retain `MqttLastWill` as public to avoid API churn mid-cycle. Document that
+packet types in `TurboMqtt.PacketTypes` are advanced/low-level and subject to change in future
+minor versions (mark with `[Experimental]`).
+
+---
+
+### 2.2 Public Types That Should Be Internal
+
+#### F-3: `MqttClient` concrete class is public
+
+**Severity:** Medium
+
+`MqttClient` is a `public sealed class` that implements the internal `IInternalMqttClient`
+interface. It should be `internal` — users obtain an `IMqttClient` from `IMqttClientFactory` and
+have no reason to reference the concrete type. Keeping it public creates an unintended API surface:
+callers may write `var client = new MqttClient(...)` or use pattern matching on the concrete type,
+making future refactoring harder.
+
+**Recommendation:** Make `MqttClient` internal before v1.0. This is a **breaking change** only if
+callers reference the concrete type, which the factory pattern discourages.
+
+**Action for v1.0:** Change `public sealed class MqttClient` → `internal sealed class MqttClient`.
+
+---
+
+#### F-4: `MqttClientFactory` concrete class is public
+
+**Severity:** Low
+
+`MqttClientFactory` is public but callers should inject `IMqttClientFactory`. Keeping it public
+exposes the `Akka.NET` constructor signature (`ActorSystem`) as API surface.
+
+**Recommendation:** No change for v1.0 — it is common practice to expose the factory concrete
+class so callers who don't use DI can `new` it directly. Document that the constructor parameter is
+subject to change in future major versions.
+
+---
+
+#### F-5: `PublishingProtocol.SetReceiveMaximum` is public
+
+**Severity:** Low
+
+`SetReceiveMaximum` is an internal actor message used between actors. It should be `internal`.
+Users have no reason to create or consume it.
+
+**Recommendation:** Make `SetReceiveMaximum` internal before v1.0.
+
+**Action for v1.0:** Change `public sealed class SetReceiveMaximum` → `internal sealed class SetReceiveMaximum`.
+
+---
+
+#### F-6: `UShortCounter` is public
+
+**Severity:** Low
+
+`UShortCounter` is a thread-safe counter used internally for packet ID generation. Users have no
+reason to reference it directly.
+
+**Recommendation:** Make `UShortCounter` internal before v1.0.
+
+**Action for v1.0:** Change `public sealed class UShortCounter` → `internal sealed class UShortCounter`.
+
+---
+
+### 2.3 `IAsyncDisposable` Consistency
+
+| Type | IAsyncDisposable | Notes |
+|------|-----------------|-------|
+| `IMqttClient` | ✅ yes | Via interface declaration |
+| `MqttClient` | ✅ yes | Inherited from `IMqttClient` |
+| `IMqttClientFactory` | ❌ no | Factory holds actor refs; does not implement disposal |
+| `MqttClientFactory` | ❌ no | See above |
+
+**Assessment:** Acceptable. Factories in .NET commonly are not disposable. The `ActorSystem` that
+backs the factory is managed externally (either by Akka.Hosting or the caller). No changes needed.
+
+---
+
+### 2.4 Extend-Only Compatibility
+
+The public API uses the following patterns that are safe for extend-only growth:
+
+| Pattern | Assessment |
+|---------|------------|
+| `sealed record` for options types | ✅ Safe — callers use `with` init; cannot subclass |
+| `sealed class` for packet types | ✅ Safe — prevents inheritance surprises |
+| Return-type interfaces (`IMqttClient`, `IPublishResult`, etc.) | ✅ Safe — implementation can change |
+| `enum : byte` for reason codes | ⚠️ Adding new values is non-breaking; removing values is breaking |
+| `interface` for response types | ✅ Adding default interface members is non-breaking in C# 8+ |
+| `static class` for `AckProtocol` | ✅ Adding new nested types is non-breaking |
+
+**Stable, no changes needed** for the core `IMqttClient` / `IMqttClientFactory` contracts.
+
+---
+
+### 2.5 Naming Consistency in `IAckResponse` Implementations
+
+`IAckResponse.Reason` is declared as `string?` (nullable). Most implementations return
+`string?` correctly, but:
+
+- `AckProtocol.SubscribeFailure.Reason` returns `string` (non-nullable) — consistent with the
+  interface since a non-nullable is assignable to nullable.
+- `AckProtocol.UnsubscribeFailure.Reason` returns `string` (non-nullable).
+
+These are technically correct (covariant return types) but are a minor inconsistency in that
+implementations don't agree on nullability. **No change needed for v1.0**.
+
+---
+
+## 3. Breaking Changes from Phase 4 (Tasks 4.6 and 4.7)
+
+Both changes were introduced before v1.0 and are therefore **not subject to SemVer**. They are
+documented here for traceability. Full rationale is in [v1.0-criteria.md](v1.0-criteria.md).
+
+### Task 4.6: `DelayInterval` type changed from `NonZeroUInt16` to `uint`
+
+**Affected types:**
+- `MqttLastWill.DelayInterval` (`PacketTypes` namespace)
+- `LastWillAndTestament.DelayInterval` (`Client` namespace)
+
+**Why:** MQTT 5.0 spec §3.1.3.2.2 defines Will Delay Interval as a Four Byte Integer (uint32,
+0–4,294,967,295). `NonZeroUInt16` truncated to 65,535 and rejected 0 (which is valid — publish
+immediately on disconnect).
+
+**Migration:** Replace `NonZeroUInt16` values with `uint`. Values of 0 are now accepted. Values
+above 65,535 are now correctly encoded/decoded.
+
+---
+
+### Task 4.7: `UserProperties` type changed from `IReadOnlyDictionary<string, string>?` to `IReadOnlyList<KeyValuePair<string, string>>?`
+
+**Affected types:** All packet types and `MqttClientConnectOptions`/`LastWillAndTestament` that
+carried `UserProperties` or `WillProperties`.
+
+**Why:** MQTT 5.0 spec §3.1.2.11.8 explicitly permits duplicate keys in User Properties.
+`IReadOnlyDictionary<string, string>` silently drops duplicate keys.
+
+**Migration:** Replace dictionary literals with list of `KeyValuePair<string, string>` objects, or
+use the new `.AsUserProperties()` extension helper (if provided). When reading properties, iterate
+with `foreach` rather than `[]` indexer.
+
+---
+
+## 4. Recommended Actions Before v1.0 Tag
+
+The following items are prioritized by severity. Items marked **MUST** block the 1.0 tag.
+
+| # | Severity | Finding | Action | Status |
+|---|----------|---------|--------|--------|
+| 1 | MUST | F-3: `MqttClient` is public | Make `internal` | Open |
+| 2 | MUST | F-5: `SetReceiveMaximum` is public | Make `internal` | Open |
+| 3 | MUST | F-6: `UShortCounter` is public | Make `internal` | Open |
+| 4 | SHOULD | F-1: `TurbotMqttHostingExtensions` typo | Rename class | Open |
+| 5 | MAY | F-2: `MqttLastWill` as public wire type | Mark `[Experimental]` or defer | Deferred |
+| 6 | MAY | F-4: `MqttClientFactory` is public | No change (by design) | Accepted |
+
+---
+
+## 5. API Surface Stability Promise for v1.0
+
+Starting from v1.0.0, TurboMqtt follows **strict SemVer** as defined in
+[v1.0-criteria.md](v1.0-criteria.md):
+
+- `TurboMqtt.Client` namespace — **stable, versioned**
+- `TurboMqtt.Protocol` namespace (response interfaces + reason codes) — **stable, versioned**
+- `TurboMqtt.PacketTypes` namespace — **advanced API**; stable for packet construction; internal
+  implementation details (encoders, decoders) carry no stability promise
+- `TurboMqtt.Protocol.Pub` publishing protocol — **stable** for `IPublishResult` and
+  `PublishingStatus`; actor messages are internal-only
+- `TurboMqtt.Utility` — **internal**; no stability promise after v1.0 cleanup

--- a/src/TurboMqtt/Client/IMqttClient.cs
+++ b/src/TurboMqtt/Client/IMqttClient.cs
@@ -144,7 +144,7 @@ internal interface IInternalMqttClient : IMqttClient
 /// <summary>
 /// Default MQTT client implementation
 /// </summary>
-public sealed class MqttClient : IInternalMqttClient
+internal sealed class MqttClient : IInternalMqttClient
 {
     private readonly MqttClientConnectOptions _options;
     // All reads must go through the Transport property (Volatile.Read);

--- a/src/TurboMqtt/Client/IMqttClient.cs
+++ b/src/TurboMqtt/Client/IMqttClient.cs
@@ -245,7 +245,7 @@ public sealed class MqttClient : IInternalMqttClient
             KeepAliveSeconds = _options.KeepAliveSeconds,
             UserName = _options.UserName,
             Password = _options.Password,
-            ConnectFlags = connectFlags,
+            Flags = connectFlags,
             MaximumPacketSize = _options.MaximumPacketSize,
             ReceiveMaximum = _options.ReceiveMaximum,
         };

--- a/src/TurboMqtt/PacketTypes/ConnectPacket.cs
+++ b/src/TurboMqtt/PacketTypes/ConnectPacket.cs
@@ -71,7 +71,6 @@ public sealed class ConnectPacket(MqttProtocolVersion protocolVersion) : MqttPac
     public string? AuthenticationMethod { get; set; } // MQTT 5.0 only
     public ReadOnlyMemory<byte>? AuthenticationData { get; set; } // MQTT 5.0 only
     public IReadOnlyList<KeyValuePair<string, string>>? UserProperties { get; set; } // MQTT 5.0 custom properties
-    public ConnectFlags ConnectFlags { get; set; }
 
     public override string ToString()
     {

--- a/src/TurboMqtt/PacketTypes/ConnectPacket.cs
+++ b/src/TurboMqtt/PacketTypes/ConnectPacket.cs
@@ -139,6 +139,10 @@ public struct ConnectFlags
     
     public static ConnectFlags Decode(byte flags)
     {
+        // MQTT-3.1.2-3: Reserved bit 0 must be 0
+        if ((flags & 0x01) != 0)
+            throw new ArgumentOutOfRangeException(nameof(flags), "[MQTT-3.1.2-3] Reserved bit 0 of CONNECT flags must be 0.");
+
         var result = new ConnectFlags
         {
             UsernameFlag = (flags & 0x80) == 0x80,
@@ -149,7 +153,13 @@ public struct ConnectFlags
         };
 
         if (result.WillFlag)
-            result.WillQoS = (QualityOfService)((flags & 0x18) >> 3);
+        {
+            var willQos = (flags & 0x18) >> 3;
+            // MQTT-3.1.2-14: WillQoS must be 0, 1, or 2 when WillFlag is set
+            if (willQos > 2)
+                throw new ArgumentOutOfRangeException(nameof(flags), "[MQTT-3.1.2-14] WillQoS must be 0, 1, or 2 when WillFlag is set.");
+            result.WillQoS = (QualityOfService)willQos;
+        }
         else if ((flags & 0x38) != 0) // reserved bit for Will 3,4,5
         {
             throw new ArgumentOutOfRangeException(nameof(flags), "[MQTT-3.1.2-11]");

--- a/src/TurboMqtt/Protocol/Mqtt311Decoder.cs
+++ b/src/TurboMqtt/Protocol/Mqtt311Decoder.cs
@@ -58,7 +58,8 @@ public class Mqtt311Decoder
             var currentPacket = workingBuffer.Span;
 
             // extract MqttPacketType
-            packetType = (MqttPacketType)(currentPacket[0] >> 4);
+            var firstByte = currentPacket[0];
+            packetType = (MqttPacketType)(firstByte >> 4);
             currentPacket = currentPacket.Slice(1);
 
             // extract packet size (the packet span will automatically advance past the size header)
@@ -126,6 +127,9 @@ public class Mqtt311Decoder
                     }
                     case MqttPacketType.PubRel:
                     {
+                        if ((firstByte & 0x0F) != 0x02)
+                            throw new ArgumentException(
+                                $"Fixed header reserved bits for PUBREL must be 0x2 [MQTT-2.2.2]; received lower nibble 0x{firstByte & 0x0F:X}.");
                         packetsBuilder.Add(DecodePubRel(ref bufferForMsg, packetSize, headerLength));
                         break;
                     }
@@ -157,11 +161,17 @@ public class Mqtt311Decoder
                     }
                     case MqttPacketType.Subscribe:
                     {
+                        if ((firstByte & 0x0F) != 0x02)
+                            throw new ArgumentException(
+                                $"Fixed header reserved bits for SUBSCRIBE must be 0x2 [MQTT-2.2.2]; received lower nibble 0x{firstByte & 0x0F:X}.");
                         packetsBuilder.Add(DecodeSubscribe(ref bufferForMsg, packetSize, headerLength));
                         break;
                     }
                     case MqttPacketType.Unsubscribe:
                     {
+                        if ((firstByte & 0x0F) != 0x02)
+                            throw new ArgumentException(
+                                $"Fixed header reserved bits for UNSUBSCRIBE must be 0x2 [MQTT-2.2.2]; received lower nibble 0x{firstByte & 0x0F:X}.");
                         packetsBuilder.Add(DecodeUnsubscribe(ref bufferForMsg, packetSize, headerLength));
                         break;
                     }

--- a/src/TurboMqtt/Protocol/Mqtt311EncoderOptimized.cs
+++ b/src/TurboMqtt/Protocol/Mqtt311EncoderOptimized.cs
@@ -39,6 +39,9 @@ public static class Mqtt311EncoderOptimized
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int EncodePacket(MqttPacket packet, Span<byte> buffer, PacketSize estimatedSize)
     {
+        if (buffer.Length < estimatedSize.TotalSize)
+            throw new ArgumentException("Buffer is too small for the estimated packet size.");
+
         return packet.PacketType switch
         {
             MqttPacketType.Publish => EncodePublishPacketOptimized((PublishPacket)packet, buffer, estimatedSize),

--- a/src/TurboMqtt/Protocol/Pub/PublishingProtocol.cs
+++ b/src/TurboMqtt/Protocol/Pub/PublishingProtocol.cs
@@ -74,7 +74,7 @@ public static class PublishingProtocol{
     /// Configures the receive maximum for the retry actor after receiving a CONNACK with ReceiveMaximum set.
     /// When set, the actor buffers QoS 1/2 publishes beyond this limit and releases them as ACKs arrive.
     /// </summary>
-    public sealed class SetReceiveMaximum
+    internal sealed class SetReceiveMaximum
     {
         public SetReceiveMaximum(ushort value) { Value = value; }
         public ushort Value { get; }

--- a/src/TurboMqtt/TurboMqttHostingExtensions.cs
+++ b/src/TurboMqtt/TurboMqttHostingExtensions.cs
@@ -1,5 +1,5 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TurbotMqttHostingExtensions.cs" company="Petabridge, LLC">
+// -----------------------------------------------------------------------
+// <copyright file="TurboMqttHostingExtensions.cs" company="Petabridge, LLC">
 //      Copyright (C) 2024 - 2024 Petabridge, LLC <https://petabridge.com>
 // </copyright>
 // -----------------------------------------------------------------------
@@ -14,7 +14,7 @@ namespace TurboMqtt;
 /// <summary>
 /// Used to tie into the Akka.NET <see cref="ActorSystem"/> and start up the TurboMqtt server.
 /// </summary>
-public static class TurbotMqttHostingExtensions
+public static class TurboMqttHostingExtensions
 {
     /// <summary>
     /// Registers the <see cref="IMqttClientFactory"/> with the <see cref="IServiceCollection"/>.
@@ -36,7 +36,7 @@ public static class TurbotMqttHostingExtensions
                 system = ActorSystem.Create("turbomqtt");
                 system.Log.Info("Created new Akka.NET ActorSystem {0} - none found in IServiceCollection", system.Name);
             }
-            
+
             return new MqttClientFactory(system);
 
         });

--- a/src/TurboMqtt/Utility/UShortCounter.cs
+++ b/src/TurboMqtt/Utility/UShortCounter.cs
@@ -6,7 +6,7 @@
 
 namespace TurboMqtt.Utility;
 
-public sealed class UShortCounter(ushort start = 0)
+internal sealed class UShortCounter(ushort start = 0)
 {
     private int _current = start;
 

--- a/tests/TurboMqtt.Tests/Client/ReconnectTimeoutSpecs.cs
+++ b/tests/TurboMqtt.Tests/Client/ReconnectTimeoutSpecs.cs
@@ -141,8 +141,12 @@ public sealed class ReconnectTimeoutSpecs : TestKit
             connectResult.IsSuccess.Should().BeTrue("initial connection should succeed");
 
             // Phase 2: kick the client — the server closes the connection, triggering reconnect
-            var kicked = server.TryKickClient("reconnect-timeout-test");
-            kicked.Should().BeTrue("server must know the client ID");
+            // Give the server a moment to register the client ID (ContinueWith callback may not have completed yet)
+            await AwaitAssertAsync(
+                () => server.TryKickClient("reconnect-timeout-test").Should().BeTrue("server must know the client ID"),
+                duration: TimeSpan.FromSeconds(1),
+                interval: TimeSpan.FromMilliseconds(10),
+                cancellationToken: cts.Token);
 
             // Phase 3: reconnect stalls (StallingServerHandle never sends CONNACK).
             //           The 500 ms CTS fires → ReconnectFailed → actor shuts down.

--- a/tests/TurboMqtt.Tests/Packets/Connect/ConnectFlagsSpecs.cs
+++ b/tests/TurboMqtt.Tests/Packets/Connect/ConnectFlagsSpecs.cs
@@ -55,6 +55,27 @@ public class ConnectFlagsSpecs
         }
     }
 
+    public class when_decoding_invalid_connect_flags
+    {
+        [Fact]
+        public void it_should_throw_when_reserved_bit_0_is_set()
+        {
+            // Bit 0 is the reserved bit - must be 0 per MQTT-3.1.2-3
+            byte flagsWithReservedBit = 0x01;
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => ConnectFlags.Decode(flagsWithReservedBit));
+            ex.Message.Should().Contain("MQTT-3.1.2-3");
+        }
+
+        [Fact]
+        public void it_should_throw_when_will_flag_set_and_will_qos_is_3()
+        {
+            // WillFlag=1 (bit 2 = 0x04), WillQoS=3 (bits 3-4 = 0x18) → invalid per MQTT-3.1.2-14
+            byte flagsWithInvalidWillQos = 0x04 | 0x18; // WillFlag + WillQoS=3
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => ConnectFlags.Decode(flagsWithInvalidWillQos));
+            ex.Message.Should().Contain("MQTT-3.1.2-14");
+        }
+    }
+
     // create test cases for serializing and deserializing ConnectFlags
     public class when_serializing_and_deserializing_connect_flags
     {

--- a/tests/TurboMqtt.Tests/Protocol/Mqtt311DecoderErrorPathSpecs.cs
+++ b/tests/TurboMqtt.Tests/Protocol/Mqtt311DecoderErrorPathSpecs.cs
@@ -380,6 +380,79 @@ public class Mqtt311DecoderErrorPathSpecs
         decoded.Topics.Should().HaveCount(2);
     }
 
+    // -------------------------------------------------------------------------
+    // 8. Fixed header reserved bits validation [MQTT-2.2.2]
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// MQTT-2.2.2: SUBSCRIBE must have lower nibble = 0x2 (first byte 0x82).
+    /// A SUBSCRIBE packet with first byte 0x80 (lower nibble 0x0) must be rejected.
+    /// </summary>
+    [Fact]
+    public void Decoder_Subscribe_WrongReservedBits_ThrowsMqttDecoderException()
+    {
+        var decoder = new Mqtt311Decoder();
+
+        // SUBSCRIBE with lower nibble 0x0 instead of required 0x2:
+        //   Fixed header: 0x80 (type=8=SUBSCRIBE, reserved=0x0 — wrong, must be 0x2)
+        //   Remaining   : 0x06 (6 bytes)
+        //   Packet ID   : { 0x00, 0x01 }
+        //   Topic "a"   : { 0x00, 0x01, 0x61 }
+        //   Options     : 0x00
+        var bytes = new byte[] { 0x80, 0x06, 0x00, 0x01, 0x00, 0x01, 0x61, 0x00 };
+        var buffer = new ReadOnlyMemory<byte>(bytes);
+
+        var act = () => decoder.TryDecode(buffer, out _);
+
+        act.Should().Throw<MqttDecoderException>(
+            "SUBSCRIBE fixed header lower nibble must be 0x2 per MQTT-2.2.2");
+    }
+
+    /// <summary>
+    /// MQTT-2.2.2: UNSUBSCRIBE must have lower nibble = 0x2 (first byte 0xA2).
+    /// A UNSUBSCRIBE packet with first byte 0xA0 (lower nibble 0x0) must be rejected.
+    /// </summary>
+    [Fact]
+    public void Decoder_Unsubscribe_WrongReservedBits_ThrowsMqttDecoderException()
+    {
+        var decoder = new Mqtt311Decoder();
+
+        // UNSUBSCRIBE with lower nibble 0x0 instead of required 0x2:
+        //   Fixed header: 0xA0 (type=10=UNSUBSCRIBE, reserved=0x0 — wrong, must be 0x2)
+        //   Remaining   : 0x05 (5 bytes)
+        //   Packet ID   : { 0x00, 0x01 }
+        //   Topic "a"   : { 0x00, 0x01, 0x61 }
+        var bytes = new byte[] { 0xA0, 0x05, 0x00, 0x01, 0x00, 0x01, 0x61 };
+        var buffer = new ReadOnlyMemory<byte>(bytes);
+
+        var act = () => decoder.TryDecode(buffer, out _);
+
+        act.Should().Throw<MqttDecoderException>(
+            "UNSUBSCRIBE fixed header lower nibble must be 0x2 per MQTT-2.2.2");
+    }
+
+    /// <summary>
+    /// MQTT-2.2.2: PUBREL must have lower nibble = 0x2 (first byte 0x62).
+    /// A PUBREL packet with first byte 0x60 (lower nibble 0x0) must be rejected.
+    /// </summary>
+    [Fact]
+    public void Decoder_PubRel_WrongReservedBits_ThrowsMqttDecoderException()
+    {
+        var decoder = new Mqtt311Decoder();
+
+        // PUBREL with lower nibble 0x0 instead of required 0x2:
+        //   Fixed header: 0x60 (type=6=PUBREL, reserved=0x0 — wrong, must be 0x2)
+        //   Remaining   : 0x02 (2 bytes)
+        //   Packet ID   : { 0x00, 0x01 }
+        var bytes = new byte[] { 0x60, 0x02, 0x00, 0x01 };
+        var buffer = new ReadOnlyMemory<byte>(bytes);
+
+        var act = () => decoder.TryDecode(buffer, out _);
+
+        act.Should().Throw<MqttDecoderException>(
+            "PUBREL fixed header lower nibble must be 0x2 per MQTT-2.2.2");
+    }
+
     /// <summary>
     /// Verifies that a CONNECT packet fragmented across three TCP segments is
     /// correctly reassembled.

--- a/tests/TurboMqtt.Tests/Protocol/Mqtt311EncoderSpecs.cs
+++ b/tests/TurboMqtt.Tests/Protocol/Mqtt311EncoderSpecs.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using TurboMqtt.PacketTypes;
 using TurboMqtt.Protocol;
 
 namespace TurboMqtt.Tests.Protocol;
@@ -52,5 +53,20 @@ public class Mqtt311EncoderSpecs
             var decoded = Mqtt311Decoder.DecodeUnsignedShort(ref readonlyMem, ref remainingLength);
             Assert.Equal(value, decoded);
         }
+    }
+}
+
+public class Mqtt311EncoderOptimizedSpecs
+{
+    [Fact]
+    public void EncodePacket_UndersizedBuffer_ThrowsArgumentException()
+    {
+        // DisconnectPacket has TotalSize = 2 (1 fixed header byte + 1 remaining-length byte)
+        var packet = new DisconnectPacket();
+        var estimatedSize = PacketSize.NoContent; // TotalSize == 2
+        var undersizedBuffer = new byte[1];
+
+        Assert.Throws<ArgumentException>(() =>
+            Mqtt311EncoderOptimized.EncodePacket(packet, undersizedBuffer.AsSpan(), estimatedSize));
     }
 }

--- a/tests/TurboMqtt.Tests/Protocol/Mqtt311RoundtripPropertyTests.cs
+++ b/tests/TurboMqtt.Tests/Protocol/Mqtt311RoundtripPropertyTests.cs
@@ -40,11 +40,9 @@ public class Mqtt311RoundtripPropertyTests
             var p = (ConnectPacket)orig;
             var d = (ConnectPacket)decoded[0];
 
-            // Exclude Will.Message (ReadOnlyMemory<byte>) and ConnectFlags (redundant property).
-            // Will.Message is compared separately below.
+            // Exclude Will.Message (ReadOnlyMemory<byte>), compared separately below.
             d.Should().BeEquivalentTo(p, options => options
-                .Excluding(x => x.Will!.Message)
-                .Excluding(x => x.ConnectFlags));
+                .Excluding(x => x.Will!.Message));
 
             if (p.Will != null)
                 d.Will!.Message.ToArray().Should().BeEquivalentTo(p.Will.Message.ToArray(),

--- a/tests/TurboMqtt.Tests/Protocol/Mqtt5DecoderErrorPathSpecs.cs
+++ b/tests/TurboMqtt.Tests/Protocol/Mqtt5DecoderErrorPathSpecs.cs
@@ -371,7 +371,79 @@ public class Mqtt5DecoderErrorPathSpecs
         packets.Should().BeEmpty();
     }
 
-    // ── 7. DISCONNECT compact form ────────────────────────────────────────────
+    // ── 7. Fixed header reserved bits validation [MQTT-2.2.2] ────────────────
+
+    /// <summary>
+    /// MQTT-2.2.2: SUBSCRIBE must have lower nibble = 0x2 (first byte 0x82).
+    /// A SUBSCRIBE packet with first byte 0x80 (lower nibble 0x0) must be rejected
+    /// by the MQTT 5.0 decoder (which inherits the same decode loop).
+    /// </summary>
+    [Fact]
+    public void Decoder_Subscribe_WrongReservedBits_ThrowsMqttDecoderException()
+    {
+        var decoder = new Mqtt5Decoder();
+
+        // SUBSCRIBE with lower nibble 0x0 instead of required 0x2:
+        //   Fixed header: 0x80 (type=8=SUBSCRIBE, reserved=0x0 — wrong, must be 0x2)
+        //   Remaining   : 0x06 (6 bytes)
+        //   Packet ID   : { 0x00, 0x01 }
+        //   Topic "a"   : { 0x00, 0x01, 0x61 }
+        //   Options     : 0x00
+        var bytes = new byte[] { 0x80, 0x06, 0x00, 0x01, 0x00, 0x01, 0x61, 0x00 };
+        var buffer = new ReadOnlyMemory<byte>(bytes);
+
+        var act = () => decoder.TryDecode(buffer, out _);
+
+        act.Should().Throw<MqttDecoderException>(
+            "SUBSCRIBE fixed header lower nibble must be 0x2 per MQTT-2.2.2");
+    }
+
+    /// <summary>
+    /// MQTT-2.2.2: UNSUBSCRIBE must have lower nibble = 0x2 (first byte 0xA2).
+    /// A UNSUBSCRIBE packet with first byte 0xA0 (lower nibble 0x0) must be rejected.
+    /// </summary>
+    [Fact]
+    public void Decoder_Unsubscribe_WrongReservedBits_ThrowsMqttDecoderException()
+    {
+        var decoder = new Mqtt5Decoder();
+
+        // UNSUBSCRIBE with lower nibble 0x0 instead of required 0x2:
+        //   Fixed header: 0xA0 (type=10=UNSUBSCRIBE, reserved=0x0 — wrong, must be 0x2)
+        //   Remaining   : 0x05 (5 bytes)
+        //   Packet ID   : { 0x00, 0x01 }
+        //   Topic "a"   : { 0x00, 0x01, 0x61 }
+        var bytes = new byte[] { 0xA0, 0x05, 0x00, 0x01, 0x00, 0x01, 0x61 };
+        var buffer = new ReadOnlyMemory<byte>(bytes);
+
+        var act = () => decoder.TryDecode(buffer, out _);
+
+        act.Should().Throw<MqttDecoderException>(
+            "UNSUBSCRIBE fixed header lower nibble must be 0x2 per MQTT-2.2.2");
+    }
+
+    /// <summary>
+    /// MQTT-2.2.2: PUBREL must have lower nibble = 0x2 (first byte 0x62).
+    /// A PUBREL packet with first byte 0x60 (lower nibble 0x0) must be rejected.
+    /// </summary>
+    [Fact]
+    public void Decoder_PubRel_WrongReservedBits_ThrowsMqttDecoderException()
+    {
+        var decoder = new Mqtt5Decoder();
+
+        // PUBREL with lower nibble 0x0 instead of required 0x2:
+        //   Fixed header: 0x60 (type=6=PUBREL, reserved=0x0 — wrong, must be 0x2)
+        //   Remaining   : 0x02 (2 bytes)
+        //   Packet ID   : { 0x00, 0x01 }
+        var bytes = new byte[] { 0x60, 0x02, 0x00, 0x01 };
+        var buffer = new ReadOnlyMemory<byte>(bytes);
+
+        var act = () => decoder.TryDecode(buffer, out _);
+
+        act.Should().Throw<MqttDecoderException>(
+            "PUBREL fixed header lower nibble must be 0x2 per MQTT-2.2.2");
+    }
+
+    // ── 8. DISCONNECT compact form ────────────────────────────────────────────
 
     /// <summary>
     /// The MQTT 5.0 compact DISCONNECT form (Remaining Length = 0) must decode

--- a/tests/TurboMqtt.Tests/Protocol/Mqtt5RoundtripPropertyTests.cs
+++ b/tests/TurboMqtt.Tests/Protocol/Mqtt5RoundtripPropertyTests.cs
@@ -66,11 +66,9 @@ public class Mqtt5RoundtripPropertyTests
             var p = (ConnectPacket)orig;
             var d = (ConnectPacket)decoded[0];
 
-            // Compare all fields except memory-typed ones (compared below) and
-            // ConnectFlags (duplicate of Flags).
+            // Compare all fields except memory-typed ones (compared below).
             d.Should().BeEquivalentTo(p, options => options
                 .Excluding(x => x.Will!.Message)
-                .Excluding(x => x.ConnectFlags)
                 .Excluding(x => x.AuthenticationData));
 
             // Will payload: compare byte content

--- a/tests/TurboMqtt.Tests/Streams/MqttDecodingFlowSpecs.cs
+++ b/tests/TurboMqtt.Tests/Streams/MqttDecodingFlowSpecs.cs
@@ -21,7 +21,7 @@ public class MqttDecodingFlowSpecs : TestKit
     {
         var connectPacket = new ConnectPacket(MqttProtocolVersion.V3_1_1)
         {
-            ClientId = "test", ConnectFlags = new ConnectFlags { CleanSession = true }, ProtocolName = "MQTT"
+            ClientId = "test", Flags = new ConnectFlags { CleanSession = true }, ProtocolName = "MQTT"
         };
         
         var encodingFlow = MqttEncodingFlows.Mqtt311Encoding(MemoryPool<byte>.Shared, 1024, 1024);
@@ -42,7 +42,7 @@ public class MqttDecodingFlowSpecs : TestKit
     {
         var connectPacket = new ConnectPacket(MqttProtocolVersion.V3_1_1)
         {
-            ClientId = "test", ConnectFlags = new ConnectFlags { CleanSession = true }, ProtocolName = "MQTT"
+            ClientId = "test", Flags = new ConnectFlags { CleanSession = true }, ProtocolName = "MQTT"
         };
         var connAckPacket = new ConnAckPacket()
         {

--- a/tests/TurboMqtt.Tests/Streams/MqttEncodingFlowSpecs.cs
+++ b/tests/TurboMqtt.Tests/Streams/MqttEncodingFlowSpecs.cs
@@ -20,7 +20,7 @@ public class MqttEncodingFlowSpecs : TestKit
     {
         var connectPacket = new ConnectPacket(MqttProtocolVersion.V3_1_1)
         {
-            ClientId = "test", ConnectFlags = new ConnectFlags { CleanSession = true }, ProtocolName = "MQTT"
+            ClientId = "test", Flags = new ConnectFlags { CleanSession = true }, ProtocolName = "MQTT"
         };
         var flow = MqttEncodingFlows.Mqtt311Encoding(MemoryPool<byte>.Shared, 1024, 1024);
 
@@ -44,7 +44,7 @@ public class MqttEncodingFlowSpecs : TestKit
     {
         var connectPacket = new ConnectPacket(MqttProtocolVersion.V3_1_1)
         {
-            ClientId = "test", ConnectFlags = new ConnectFlags { CleanSession = true }, ProtocolName = "MQTT"
+            ClientId = "test", Flags = new ConnectFlags { CleanSession = true }, ProtocolName = "MQTT"
         };
         var connAckPacket = new ConnAckPacket()
         {


### PR DESCRIPTION
## Summary

This PR completes the remaining MQTT spec compliance and code quality tasks planned for v1.0 release:

- **Task 6.5**: Remove duplicate ConnectPacket.ConnectFlags property
- **Task 6.6**: Add ConnectFlags reserved bit and WillQoS validation
- **Task 6.7**: Validate fixed header reserved bits for SUBSCRIBE/UNSUBSCRIBE/PUBREL
- **Task 6.8**: Add buffer size validation to Mqtt311EncoderOptimized
- **Task 6.9**: Make MqttClient, SetReceiveMaximum, and UShortCounter internal
- **Task 6.10**: Rename TurbotMqttHostingExtensions to TurboMqttHostingExtensions

Also includes API stability review documentation for v1.0 release.

## Changes
- 8 commits with spec compliance validations
- New error path tests for MQTT 3.1.1 and 5.0 decoders
- API review documentation
- 688 insertions across 20 files

## Test Plan
- All unit and integration tests pass
- MQTT 3.1.1 and 5.0 spec validation tests included
- Benchmarks remain unaffected