### PR TITLE
Fix NU1903 build errors: pin vulnerable transitive NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,11 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
+  <!-- Transitive dependency overrides to resolve known vulnerabilities -->
+  <ItemGroup Label="SecurityOverrides">
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
+  </ItemGroup>
   <!-- Test Package Versions -->
   <ItemGroup>
     <PackageVersion Include="Akka.Hosting.TestKit" Version="$(AkkaHostingVersion)" />


### PR DESCRIPTION
## Summary

- Pins `System.Net.Http` to `4.3.4` (was resolving to vulnerable `4.1.0` transitively)
- Pins `System.Security.Cryptography.X509Certificates` to `4.3.2` (was resolving to vulnerable `4.1.0` transitively)
- Both overrides added to `Directory.Packages.props` under a `SecurityOverrides` item group

These old versions were pulled in transitively by `FsCheck` 2.x (which targets `netstandard1.x`). With Central Package Management, `PackageVersion` entries act as a resolution floor, forcing NuGet to select the patched versions.

Resolves NuGet audit advisories: GHSA-7jgj-8wvc-jh57, GHSA-7mfr-774f-w5r9

## Test plan

- [x] `dotnet build -c Release` passes with 0 warnings and 0 errors