### PR TITLE
Prepare v1.0.0-beta1 release: update docs and release notes

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -44,8 +44,8 @@ ActorSystem
 
 | Protocol | Status |
 |----------|--------|
-| MQTT 3.1.1 | Implemented (production hardening in progress) |
-| MQTT 5.0 | Packet infrastructure exists; not yet functional |
+| MQTT 3.1.1 | Implemented |
+| MQTT 5.0 | Implemented (encoder/decoder, User Properties, server-initiated DISCONNECT, auth; validated against EMQX 5.x) |
 | MQTT over QUIC | Roadmap only |
 | TLS | Implemented (via `TlsStreamProvider` + `MqttClientTlsOptions`) |
 
@@ -59,16 +59,14 @@ ActorSystem
 
 ## Current State
 
-- **Version**: 0.3.0-beta (in-progress; last published release was 0.2.0, June 2024)
-- **Priority**: MQTT 3.1.1 production readiness (epic #66)
-- **Known issues**: CI/CD GitHub Release broken (#74), flaky test (#99), dependabot PR backlog
-- **In-flight features**: AOT canary, decoder perf optimization
+- **Version**: 1.0.0-beta1 (in-progress; last published release was 0.2.0, June 2024)
+- **Priority**: v1.0.0 release validation
+- **Known issues**: Signing workflow untested with new certificate (first live test on beta push)
 
 ## Roadmap
 
-1. MQTT 3.1.1 production readiness (current)
-2. MQTT 5.0 support (epic #67)
-3. MQTT over QUIC (epic #68)
+1. v1.0.0 stable release
+2. MQTT over QUIC (epic #68)
 
 ## Repository Layout
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TurboMqtt
 
-[TurboMqtt](https://github.com/petabridge/TurboMqtt) is a high-speed Message Queue Telemetry Transport (MQTT) client designed to support large-scale IOT workloads, handling over 100k msg/s from any MQTT 3.1.1+ broker.
+[TurboMqtt](https://github.com/petabridge/TurboMqtt) is a high-speed Message Queue Telemetry Transport (MQTT) client designed to support large-scale IOT workloads, handling over 100k msg/s from any MQTT 3.1.1 or MQTT 5.0 broker.
 
 ![TurboMqtt logo](https://raw.githubusercontent.com/petabridge/TurboMqtt/dev/docs/logo.png)
 
@@ -8,7 +8,7 @@ TurboMqtt is written on top of [Akka.NET](https://getakka.net/) and Akka.Streams
 
 ## Key Features
 
-* **MQTT 3.1.1 support** — Production-ready for v1.0 (MQTT 5.0 coming in v1.1);
+* **MQTT 3.1.1 and MQTT 5.0 support** — Full support for both protocol versions, validated against EMQX 5.x;
 * Extremely high performance - hundreds of thousands of messages per second;
 * Extremely resource-efficient - pools memory and leverages asynchronous I/O best practices;
 * Extremely robust fault tolerance - this is one of [Akka.NET's great strengths](https://petabridge.com/blog/akkadotnet-actors-restart/) and we've leveraged it in TurboMqtt;
@@ -27,16 +27,12 @@ Simple interface that works at very high rates of speed with minimal resource ut
 | Document | Description |
 |----------|-------------|
 | [QuickStart](#quickstart) | Install, connect, publish, and subscribe in minutes |
-| [Connection Lifecycle](docs/connection-lifecycle.md) | Client states, reconnection behavior, `DisconnectAsync` vs `DisposeAsync` |
-| [Quality of Service (QoS)](docs/qos.md) | When to use QoS 0, 1, or 2; backpressure and flow control |
-| [Performance](docs/performance.md) | Benchmarks, throughput metrics, benchmark reproduction |
-| [OpenTelemetry](docs/telemetry.md) | Metrics, tracing, and how to wire up OTLP exporters |
+| [Connection Lifecycle](https://github.com/petabridge/TurboMqtt/blob/dev/docs/connection-lifecycle.md) | Client states, reconnection behavior, `DisconnectAsync` vs `DisposeAsync` |
+| [Quality of Service (QoS)](https://github.com/petabridge/TurboMqtt/blob/dev/docs/qos.md) | When to use QoS 0, 1, or 2; backpressure and flow control |
+| [Performance](https://github.com/petabridge/TurboMqtt/blob/dev/docs/performance.md) | Benchmarks, throughput metrics, benchmark reproduction |
+| [OpenTelemetry](https://github.com/petabridge/TurboMqtt/blob/dev/docs/telemetry.md) | Metrics, tracing, and how to wire up OTLP exporters |
 
 ## QuickStart
-
-### ⚠️ MQTT Version Note
-
-**TurboMqtt v1.0 supports MQTT 3.1.1 only.** MQTT 5.0 packet infrastructure is included but end-to-end support is coming in v1.1. Use MQTT 3.1.1 for production deployments.
 
 To get started with TurboMqtt:
 
@@ -132,11 +128,11 @@ var tlsOptions = new MqttClientTlsOptions
 
 TurboMqtt includes several sample applications to help you get started:
 
-- **[QuickStart](samples/TurboMqtt.Samples.QuickStart/)** — Minimal example with no dependency injection; perfect for copy-paste into your code
-- **[TLS Client](samples/TurboMqtt.Samples.TlsClient/)** — TLS/SSL connection with certificate validation options
-- **[Exactly-Once Delivery](samples/TurboMqtt.Samples.ExactlyOnce/)** — QoS 2 publish/subscribe demonstrating exactly-once guarantees
-- **[Backpressure Producer](samples/TurboMqtt.Samples.BackpressureProducer/)** — High-throughput publishing with DI and OpenTelemetry metrics
-- **[DevNull Consumer](samples/TurboMqtt.Samples.DevNullConsumer/)** — High-speed message consumption to measure throughput
+- **[QuickStart](https://github.com/petabridge/TurboMqtt/tree/dev/samples/TurboMqtt.Samples.QuickStart/)** — Minimal example with no dependency injection; perfect for copy-paste into your code
+- **[TLS Client](https://github.com/petabridge/TurboMqtt/tree/dev/samples/TurboMqtt.Samples.TlsClient/)** — TLS/SSL connection with certificate validation options
+- **[Exactly-Once Delivery](https://github.com/petabridge/TurboMqtt/tree/dev/samples/TurboMqtt.Samples.ExactlyOnce/)** — QoS 2 publish/subscribe demonstrating exactly-once guarantees
+- **[Backpressure Producer](https://github.com/petabridge/TurboMqtt/tree/dev/samples/TurboMqtt.Samples.BackpressureProducer/)** — High-throughput publishing with DI and OpenTelemetry metrics
+- **[DevNull Consumer](https://github.com/petabridge/TurboMqtt/tree/dev/samples/TurboMqtt.Samples.DevNullConsumer/)** — High-speed message consumption to measure throughput
 
 ### Publishing Messages
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,26 @@
+#### 1.0.0-beta1 February 23rd 2026 ####
+
+TurboMqtt v1.0.0-beta1 is a major release bringing full MQTT 5.0 support, TLS/mTLS, a redesigned transport layer, and a significant round of bug fixes and spec compliance work.
+
+**New Features**
+
+* [Full MQTT 5.0 support](https://github.com/petabridge/TurboMqtt/pull/373) — complete encoder/decoder, User Properties on CONNECT and PUBLISH, server-initiated DISCONNECT handling, and authentication; validated end-to-end against EMQX 5.x.
+* [TLS/mTLS support](https://github.com/petabridge/TurboMqtt/pull/340) — `CreateTlsTcpClient` with `MqttClientTlsOptions` for server certificate validation, self-signed certs, and mutual TLS with client certificates.
+* [Transport layer redesign](https://github.com/petabridge/TurboMqtt/pull/340) — cleaner separation between TCP, TLS, and fake transports; improved testability.
+* [.NET 10 support](https://github.com/petabridge/TurboMqtt/pull/333) — now targets `net10.0`; upgraded CI to .NET 10 SDK.
+
+**Bug Fixes**
+
+* [Fix HeartBeatActor firing heartbeat timeout twice on slow reconnects](https://github.com/petabridge/TurboMqtt/pull/382).
+* [Fix two race conditions in TcpTransportActor causing flaky tests on Linux](https://github.com/petabridge/TurboMqtt/pull/380).
+* [Fix race condition causing spurious reconnect during user-initiated disconnect](https://github.com/petabridge/TurboMqtt/pull/343).
+* [Fix race: remove internal connect deadline from ClientAcksActor](https://github.com/petabridge/TurboMqtt/pull/352).
+
+**Performance**
+
+* [Major MQTT encoder performance optimizations and decoder fixes](https://github.com/petabridge/TurboMqtt/pull/295).
+* [Harden encoders against packet overflows](https://github.com/petabridge/TurboMqtt/pull/228).
+
 #### 0.2.0 June 14th 2024 ####
 
 * License has been migrated to Apache 2.0


### PR DESCRIPTION
## Summary

- Add `1.0.0-beta1` entry to `RELEASE_NOTES.md` covering MQTT 5.0, TLS, transport redesign, .NET 10, bug fixes, and performance improvements
- Update `README.md`: reflect full MQTT 5.0 support, remove stale "coming in v1.1" warning box, convert all relative doc/sample links to absolute GitHub URLs for NuGet client compatibility
- Update `PROJECT_CONTEXT.md`: MQTT 5.0 marked as implemented, current state and roadmap updated to reflect v1.0.0 release track

## Test plan

- [ ] Verify README renders correctly on GitHub and NuGet preview
- [ ] Verify all doc/sample links resolve correctly
- [ ] Confirm `build.ps1` picks up `1.0.0-beta1` from `RELEASE_NOTES.md` correctly when tagging