### PR TITLE
Fix flaky HeartbeatFailure test and remove tests from release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,9 +38,6 @@ jobs:
       - name: Build
         run: dotnet build -c Release
 
-      - name: Test
-        run: dotnet test -c Release tests/TurboMqtt.Tests/
-
       - name: Pack
         run: dotnet pack -c Release -o ./bin/nuget
 

--- a/tests/TurboMqtt.Tests/End2End/TcpMqtt311HeartbeatFailureEnd2EndSpecs.cs
+++ b/tests/TurboMqtt.Tests/End2End/TcpMqtt311HeartbeatFailureEnd2EndSpecs.cs
@@ -40,7 +40,9 @@ public class TcpMqtt311HeartbeatFailureEnd2EndSpecs : TestKit
             Password = "testpassword",
             KeepAliveSeconds = 1, // can't make it any lower than 1 second without disabling it, curse you type system
             MaxReconnectAttempts = 1, // allow 1 reconnection attempt
-            PublishRetryInterval = TimeSpan.FromMilliseconds(250)
+            // Use the default 5 s PublishRetryInterval — 250 ms was too tight for loaded CI
+            // runners where SUBACK delivery exceeds the ACK wait window, causing subscribe
+            // to report Timeout while the actual SubAck arrives just afterward.
         };
 
     public async Task<IMqttClient> CreateClient()


### PR DESCRIPTION
## Summary

- **Fix flaky `ShouldAutomaticallyReconnectandSubscribeAfterHeartbeatFailure`**: `PublishRetryInterval = 250 ms` in `DefaultConnectOptions` was too tight for loaded CI runners — SUBACK delivery exceeded the ACK wait window, causing `SubscribeAsync` to report `Timeout` while the actual SubAck arrived immediately afterward. Removed the override to use the 5 s default.

- **Remove `Test` step from `release.yaml`**: Tests already run in PR validation before a tag is ever pushed; repeating them in the release job adds latency with no additional safety gate.

## Test plan

- [ ] `TcpMqtt311HeartbeatFailureEnd2EndSpecs.ShouldAutomaticallyReconnectandSubscribeAfterHeartbeatFailure` passes on Ubuntu and Windows CI
- [ ] All other tests pass (no regressions)
- [ ] Release workflow YAML is syntactically valid (`dotnet build` step remains)