### PR TITLE
Fix release workflow: trigger on bare version tags (no v prefix)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - 'v*'
+      - '[0-9]*'
 
 permissions:
   contents: write
@@ -34,7 +34,7 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Build
         run: dotnet build -c Release


### PR DESCRIPTION
## Summary

- Change tag trigger pattern from `v*` to `[0-9]*` to match bare version tags like `1.0.0-beta1`
- Remove the `#v` strip from the version extraction step since there is no prefix to strip