### PR TITLE
Fix dotnet-sign auth: add GitHub environment + remove redundant WIF flags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
   release:
     name: Build, Sign, and Publish
     runs-on: ubuntu-latest
+    environment: signing
     env:
       CODE_SIGN_KEY_VAULT: ${{ secrets.CODE_SIGN_KEY_VAULT }}
 
@@ -63,9 +64,8 @@ jobs:
           --description "TurboMqtt"
           --description-url "https://github.com/petabridge/TurboMqtt"
           --azure-key-vault-url "${{ secrets.CODE_SIGN_KEY_VAULT }}"
-          --azure-key-vault-client-id "${{ secrets.AZURE_CLIENT_ID }}"
-          --azure-key-vault-tenant-id "${{ secrets.AZURE_TENANT_ID }}"
           --azure-key-vault-certificate "${{ secrets.CODE_SIGN_CERT_NAME }}"
+          -v Information
 
       - name: Push to NuGet.org
         run: >


### PR DESCRIPTION
## Summary

- Add `environment: signing` to the release job so the OIDC token subject matches the federated credential (`repo:petabridge/TurboMqtt:environment:signing`)
- Remove `--azure-key-vault-client-id` and `--azure-key-vault-tenant-id` from the `sign` step — `azure/login` handles OIDC auth and `dotnet sign` picks up credentials automatically via `DefaultAzureCredential`/`AzureCliCredential`
- Add `-v Information` for signing step visibility

**Azure-side prerequisites (already completed):**
- GitHub environment `signing` created on `petabridge/TurboMqtt`
- Federated credential `gha-turbomqtt-signing` created on the `CodeSigner` managed identity with subject `repo:petabridge/TurboMqtt:environment:signing`

## Test plan

- [ ] Push a bare version tag (e.g. `1.0.0`) to trigger the release workflow
- [ ] Confirm the job shows the `signing` environment badge in the Actions UI
- [ ] Confirm `Azure login` step succeeds (OIDC exchange)
- [ ] Confirm `Sign NuGet packages` step completes without auth errors
- [ ] Confirm signed `.nupkg` files are pushed to NuGet.org and attached to the GitHub Release