### PR TITLE
Fix dotnet-sign install: add --prerelease for 0.9.x versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install dotnet-sign
         if: env.CODE_SIGN_KEY_VAULT != ''
-        run: dotnet tool install --global sign --version 0.9.*
+        run: dotnet tool install --global sign --version 0.9.* --prerelease
 
       - name: Sign NuGet packages
         if: env.CODE_SIGN_KEY_VAULT != ''


### PR DESCRIPTION
## Summary

- The `sign` tool has no stable releases — all 0.9.x versions are pre-release (e.g. `0.9.1-beta.26102.1`)
- `--version 0.9.*` without `--prerelease` finds nothing and fails with exit code 1
- Adding `--prerelease` lets the wildcard match the latest `0.9.x` pre-release