### PR TITLE
Fix flaky ReconnectSuccess_ReturnsToRunning test on Windows CI

### DIFF
--- a/tests/TurboMqtt.Tests/Client/ClientStreamOwnerReconnectingSpecs.cs
+++ b/tests/TurboMqtt.Tests/Client/ClientStreamOwnerReconnectingSpecs.cs
@@ -116,8 +116,11 @@ public sealed class ClientStreamOwnerReconnectingSpecs : TestKit
 
             // Phase 2: kick the client; EventFilter waits for the actor to process
             // ReconnectSuccess and log the transition back to Running state.
+            // Must pass an explicit timeout that exceeds the reconnect delay plus overhead.
+            // The default 3 s EventFilter timeout is too tight for Windows CI runners where
+            // thread pool starvation can delay BeginReconnect's RunTask by 3+ seconds.
             await EventFilter.Info(contains: "Reconnect succeeded. Returning to Running state.")
-                .ExpectAsync(1, async () =>
+                .ExpectAsync(1, TimeSpan.FromSeconds(12), async () =>
                 {
                     var kicked = server.TryKickClient("reconnect-success-test");
                     kicked.Should().BeTrue("server must have the client registered");


### PR DESCRIPTION
## Summary

- Increased `EventFilter.ExpectAsync` timeout from the default 3 seconds to 12 seconds in `ReconnectSuccess_ReturnsToRunning` test
- On Windows CI runners, thread pool starvation can delay the `BeginReconnect` `RunTask` by 3+ seconds, causing the default timeout to expire before the reconnect completes
- This matches the explicit 12-second timeout already used by the sibling `ReconnectFailed_WithRemainingAttempts_Retries` test

## Test plan

- [x] All 4 `ClientStreamOwnerReconnectingSpecs` tests pass locally on Linux
- [ ] CI passes on both Ubuntu and Windows runners