### PR TITLE
Create GitHub Release only after NuGet publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,7 +149,7 @@ jobs:
 
   publish-github:
     name: Create GitHub Release
-    needs: sign
+    needs: publish-nuget
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Changed `publish-github` job to depend on `publish-nuget` instead of `sign`
- Ensures the GitHub Release announcement only goes out after packages are available on NuGet.org

## Test plan

- [ ] Verify on next release that the GitHub Release job waits for NuGet publish to complete